### PR TITLE
Fix Debian Packaging and other bugs

### DIFF
--- a/.github/workflows/push_to_apt.yml
+++ b/.github/workflows/push_to_apt.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd /tmp
           apt update
-          apt install -y python3-requests python3-fuzzywuzzy python3-grpcio python3-protobuf python3-aiohttp python3-pytest
+          apt install -y python3-requests python3-aiohttp
           echo 'y' | mk-build-deps -i ${GITHUB_WORKSPACE}/debian/control
 
       - name: Build package

--- a/.github/workflows/push_to_apt.yml
+++ b/.github/workflows/push_to_apt.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd /tmp
           apt update
-          apt install -y python3-requests python3-fuzzywuzzy python3-grpcio python3-protobuf python3-aiohttp
+          apt install -y python3-requests python3-fuzzywuzzy python3-grpcio python3-protobuf python3-aiohttp python3-pytest
           echo 'y' | mk-build-deps -i ${GITHUB_WORKSPACE}/debian/control
 
       - name: Build package

--- a/debian/rules
+++ b/debian/rules
@@ -6,3 +6,6 @@ export HATCH_VERBOSE=3
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_auto_test:
+    echo "disabling dh_auto_test as automated ci/cd tests are run in a separate pipeline"

--- a/debian/rules
+++ b/debian/rules
@@ -8,4 +8,4 @@ export HATCH_VERBOSE=3
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_test:
-    echo "disabling dh_auto_test as automated ci/cd tests are run in a separate pipeline"
+	echo "disabling dh_auto_test as automated ci/cd tests are run in a separate pipeline"

--- a/pydoover/config/__init__.py
+++ b/pydoover/config/__init__.py
@@ -58,7 +58,7 @@ class Schema:
 
     """
 
-    __element_map: "dict[str, ConfigElement]"
+    __element_map: "dict[str, ConfigElement]" = {}
 
     def add_element(self, element):
         try:

--- a/pydoover/docker/application.py
+++ b/pydoover/docker/application.py
@@ -122,6 +122,7 @@ class Application:
         )
 
         self.app_key = app_key
+        self.app_display_name = ""
 
         self._is_async = get_is_async(is_async)
         self._ready = asyncio.Event()
@@ -165,6 +166,9 @@ class Application:
 
         self.device_agent.agent_id = app_config.get("AGENT_ID")
         log.info(f"Agent ID set: {self.device_agent.agent_id}")
+
+        self.app_display_name = app_config.get("APP_DISPLAY_NAME", "")
+        log.info(f"Application display name set: {self.app_display_name}")
 
         log.info(f"Deployment Config Updated: {app_config}")
         self.config._inject_deployment_config(app_config)
@@ -788,6 +792,7 @@ class Application:
     async def _setup(self):
         log.info(f"Setting up internal app: {self.name}")
         self.ui_manager.register_callbacks(self)
+        self.ui_manager.set_display_name(self.app_display_name)
         self.device_agent.add_subscription(TAG_CHANNEL_NAME, self._on_tag_update)
         await self.ui_manager.clear_ui_async()
 

--- a/pydoover/docker/device_agent/device_agent.py
+++ b/pydoover/docker/device_agent/device_agent.py
@@ -66,6 +66,7 @@ class DeviceAgentInterface(GRPCInterface):
         self.is_dda_available = False
         self.is_dda_online = False
         self.has_dda_been_online = False
+        self.agent_id = None
 
         # this is a list of channels that the agent interface will subscribe to,
         # and a list of callbacks that will be called when a message is received,

--- a/pydoover/ui/element.py
+++ b/pydoover/ui/element.py
@@ -235,17 +235,30 @@ class ConnectionInfo(Element):
 class AlertStream(Element):
     """Represents an Alert Stream UI Element
 
+    .. note::
+
+        This is a special element that is used to display the "Notifications" banner in the UI.
+        If any installed app includes this element, it will be shown.
+        Do not change the name of this element, doing so will lead to confusion as
+        it is manually set to listen to the "significantEvent" channel in the UI.
+
     Parameters
     ----------
     name: str
         The name of the alert stream.
+        This defaults to "significantEvent", but is currently unused in the UI.
     display_name: str, optional
-        The display name of the alert stream.
+        The display name of the alert stream. This is not used in the UI.
     """
 
     type = "uiAlertStream"
 
-    def __init__(self, name, display_name: str = None, **kwargs):
+    def __init__(
+        self,
+        name: str = "significantEvent",
+        display_name: str = "placeholder",
+        **kwargs,
+    ):
         super().__init__(name, display_name, is_available=None, help_str=None, **kwargs)
 
 


### PR DESCRIPTION
- Skip tests for debian packaging (requires a bunch of dependencies)
- Add support for passing the display name through config
- Fix bug with simulator DDAs not getting `agent_id` with deployment config
- Set default values for AlertStream to avoid confusion