### PR TITLE
Changed RPC Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ debian/*.substvars
 
 # Generated debian package directory
 debian/doover-pydoover/
+
+local/

--- a/pydoover/api/data/_async.py
+++ b/pydoover/api/data/_async.py
@@ -5,7 +5,7 @@ Usage::
     from pydoover.api import AsyncDataClient
 
     async with AsyncDataClient("https://data.doover.com/api", token="...") as client:
-        channel = await client.fetch_channel(agent_id, "my_channel")
+        channel = await client.fetch_channel("my_channel", agent_id=123)
 """
 
 import asyncio
@@ -210,11 +210,12 @@ class AsyncDataClient(BaseClient):
 
     async def list_channels(
         self,
-        agent_id: int,
         include_aggregate: bool = True,
         include_daily_summaries: bool = True,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Channel]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels",
@@ -228,11 +229,12 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_channel(
         self,
-        agent_id: int,
         channel_name: str,
         include_aggregate: bool = True,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Channel:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}",
@@ -243,14 +245,15 @@ class AsyncDataClient(BaseClient):
 
     async def create_channel(
         self,
-        agent_id: int,
         channel_name: str,
         is_private: bool = False,
         message_schema: dict | None = None,
         aggregate_schema: dict | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> int:
         """Create a channel. Returns the new channel's snowflake ID."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"is_private": is_private}
         if message_schema is not None:
             payload["message_schema"] = message_schema
@@ -266,13 +269,14 @@ class AsyncDataClient(BaseClient):
 
     async def put_channel(
         self,
-        agent_id: int,
         channel_name: str,
         is_private: bool,
         message_schema: dict | None = None,
         aggregate_schema: dict | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Channel:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"is_private": is_private}
         if message_schema is not None:
             payload["message_schema"] = message_schema
@@ -288,13 +292,14 @@ class AsyncDataClient(BaseClient):
 
     async def list_data_series(
         self,
-        agent_id: int,
         field_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> dict[str, Any]:
+        agent_id = self._resolve_agent_id(agent_id)
         return await self._request(
             "GET",
             f"/agents/{agent_id}/data_series",
@@ -311,14 +316,15 @@ class AsyncDataClient(BaseClient):
 
     async def list_messages(
         self,
-        agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
         field_names: list[str] | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Message]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages",
@@ -334,11 +340,11 @@ class AsyncDataClient(BaseClient):
 
     def iter_messages(
         self,
-        agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         field_names: list[str] | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
         page_size: int = 50,
     ) -> AsyncMessageIterator:
@@ -347,10 +353,11 @@ class AsyncDataClient(BaseClient):
         Use as ``async for msg in client.iter_messages(...)`` or call
         ``await .collect()`` to load all matching messages into a list.
         """
+        agent_id = self._resolve_agent_id(agent_id)
         return AsyncMessageIterator(
             self,
-            agent_id,
             channel_name,
+            agent_id=agent_id,
             before=before,
             after=after,
             field_names=field_names,
@@ -360,11 +367,12 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -374,14 +382,15 @@ class AsyncDataClient(BaseClient):
 
     async def create_message(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
         timestamp: int | None = None,
         files: list[File] | None = None,
         message_id: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"data": data}
         if timestamp is not None:
             if isinstance(timestamp, datetime):
@@ -404,17 +413,18 @@ class AsyncDataClient(BaseClient):
 
     async def update_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
         data: dict[str, Any],
-        replace: bool = True,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message | None:
-        method = "PUT" if replace else "PATCH"
+        agent_id = self._resolve_agent_id(agent_id)
+        method = "PUT" if replace_data else "PATCH"
         result = await self._request(
             method,
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -432,11 +442,12 @@ class AsyncDataClient(BaseClient):
 
     async def delete_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         await self._request(
             "DELETE",
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -464,14 +475,15 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_timeseries(
         self,
-        agent_id: int,
         channel_name: str,
         field_names: list[str],
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> TimeseriesResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages/timeseries",
@@ -489,10 +501,11 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_channel_aggregate(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Aggregate:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/aggregate",
@@ -502,17 +515,18 @@ class AsyncDataClient(BaseClient):
 
     async def update_channel_aggregate(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
-        replace: bool = False,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
         log_update: bool = False,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Aggregate | None:
-        method = "PUT" if replace else "PATCH"
+        agent_id = self._resolve_agent_id(agent_id)
+        method = "PUT" if replace_data else "PATCH"
         result = await self._request(
             method,
             f"/agents/{agent_id}/channels/{channel_name}/aggregate",
@@ -531,12 +545,13 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_channel_aggregate_attachment(
         self,
-        agent_id: int,
         channel_name: str,
         attachment_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> bytes:
         """Download an aggregate attachment. Follows the redirect to S3."""
+        agent_id = self._resolve_agent_id(agent_id)
         self._ensure_session()
         assert self._session is not None
         await self.auth.ensure_token()
@@ -599,10 +614,11 @@ class AsyncDataClient(BaseClient):
 
     async def list_alarms(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Alarm]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/alarms",
@@ -612,11 +628,12 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/alarms/{alarm_id}",
@@ -626,7 +643,6 @@ class AsyncDataClient(BaseClient):
 
     async def create_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         name: str,
         key: str,
@@ -635,8 +651,10 @@ class AsyncDataClient(BaseClient):
         description: str = "",
         enabled: bool = True,
         expiry_mins: float | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "key": key,
@@ -657,7 +675,6 @@ class AsyncDataClient(BaseClient):
 
     async def put_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
         name: str,
@@ -667,8 +684,10 @@ class AsyncDataClient(BaseClient):
         description: str = "",
         enabled: bool = True,
         expiry_mins: float | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "key": key,
@@ -689,7 +708,6 @@ class AsyncDataClient(BaseClient):
 
     async def update_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
         name: str | None = None,
@@ -699,8 +717,10 @@ class AsyncDataClient(BaseClient):
         description: str | None = None,
         enabled: bool | None = None,
         expiry_mins: float | None | Unset = UNSET,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -726,11 +746,12 @@ class AsyncDataClient(BaseClient):
 
     async def delete_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         await self._request(
             "DELETE",
             f"/agents/{agent_id}/channels/{channel_name}/alarms/{alarm_id}",
@@ -741,9 +762,10 @@ class AsyncDataClient(BaseClient):
 
     async def list_connections(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionDetail]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections",
@@ -765,13 +787,14 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_connection_history(
         self,
-        agent_id: int,
         default_connection: bool,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionDetail]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections/history",
@@ -787,14 +810,15 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_subscription_history(
         self,
-        agent_id: int,
         channel_agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionSubscriptionLog]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections/subscriptions/history",
@@ -812,10 +836,11 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_channel_subscriptions(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/subscriptions",
@@ -827,9 +852,10 @@ class AsyncDataClient(BaseClient):
 
     async def fetch_notifications(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> AgentNotificationResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/notifications",
@@ -839,10 +865,11 @@ class AsyncDataClient(BaseClient):
 
     async def list_notification_endpoints(
         self,
-        agent_id: int,
         name: str | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationEndpoint]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/notifications/endpoints",
@@ -853,15 +880,16 @@ class AsyncDataClient(BaseClient):
 
     async def create_notification_endpoint(
         self,
-        agent_id: int,
         name: str,
         type: NotificationType | int,
         extra_data: dict[str, Any],
         default: bool,
         priority: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> int:
         """Create a notification endpoint. Returns the new endpoint's snowflake ID."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "type": NotificationType(type).value,
@@ -880,13 +908,14 @@ class AsyncDataClient(BaseClient):
 
     async def update_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
         name: str | None = None,
         extra_data: dict[str, Any] | None = None,
         priority: int | None | Unset = UNSET,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -903,10 +932,11 @@ class AsyncDataClient(BaseClient):
 
     async def delete_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         await self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/endpoints/{endpoint_id}",
@@ -915,10 +945,11 @@ class AsyncDataClient(BaseClient):
 
     async def test_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> bool:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "POST",
             f"/agents/{agent_id}/notifications/endpoints/{endpoint_id}/test",
@@ -928,10 +959,11 @@ class AsyncDataClient(BaseClient):
 
     async def list_notification_subscriptions(
         self,
-        agent_id: int,
         subscribed_to: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscriptions",
@@ -942,14 +974,15 @@ class AsyncDataClient(BaseClient):
 
     async def create_notification_subscription(
         self,
-        agent_id: int,
         subscribe_to: int,
         severity: NotificationSeverity | int,
         topic_filter: list[str],
         endpoint_id: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[dict[str, int]]:
         """Returns a list of created subscriptions, each with ``id`` and ``endpoint_id``."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "subscribe_to": str(subscribe_to),
             "severity": NotificationSeverity(severity).value,
@@ -970,12 +1003,13 @@ class AsyncDataClient(BaseClient):
 
     async def update_notification_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
         severity: NotificationSeverity | int | None = None,
         topic_filter: list[str] | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if severity is not None:
             payload["severity"] = NotificationSeverity(severity).value
@@ -990,10 +1024,11 @@ class AsyncDataClient(BaseClient):
 
     async def delete_notification_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         await self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/subscriptions/{subscription_id}",
@@ -1002,10 +1037,11 @@ class AsyncDataClient(BaseClient):
 
     async def list_default_notification_subscriptions(
         self,
-        agent_id: int,
         subscribed_to: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscriptions/default",
@@ -1016,10 +1052,11 @@ class AsyncDataClient(BaseClient):
 
     async def delete_default_notification_subscription(
         self,
-        agent_id: int,
         subscribed_to: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         await self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/subscriptions/default/{subscribed_to}",
@@ -1028,9 +1065,10 @@ class AsyncDataClient(BaseClient):
 
     async def list_notification_subscribers(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = await self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscribers",
@@ -1088,13 +1126,14 @@ class AsyncDataClient(BaseClient):
 
     async def put_schedule(
         self,
-        agent_id: int,
         schedule_id: int,
         app_key: str,
         permissions: list[dict[str, str]],
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> ProcessorTokenResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "app_key": app_key,
             "permissions": permissions,
@@ -1111,14 +1150,15 @@ class AsyncDataClient(BaseClient):
 
     async def put_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
         subscription_arn: str,
         app_key: str,
         permissions: list[dict[str, str]],
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "subscription_arn": subscription_arn,
             "app_key": app_key,
@@ -1135,7 +1175,6 @@ class AsyncDataClient(BaseClient):
 
     async def create_ingestion_endpoint(
         self,
-        agent_id: int,
         ingestion_id: int,
         lambda_arn: str,
         cidr_ranges: list[str],
@@ -1147,8 +1186,10 @@ class AsyncDataClient(BaseClient):
         never_replace_token: bool = False,
         mini_token: bool = False,
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> ProcessorTokenResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "lambda_arn": lambda_arn,
             "cidr_ranges": cidr_ranges,

--- a/pydoover/api/data/_base.py
+++ b/pydoover/api/data/_base.py
@@ -90,6 +90,7 @@ class BaseClient:
         *,
         auth: SyncAuthClient | AsyncAuthClient,
         owns_auth: bool = False,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
         max_retries: int = 3,
         retry_delay: float = 1.0,
@@ -97,6 +98,7 @@ class BaseClient:
     ):
         self.base_url = base_url.rstrip("/")
         self.auth = auth
+        self.agent_id: int | None = int(agent_id) if agent_id else None
         self.organisation_id: int | None = (
             int(organisation_id) if organisation_id else None
         )
@@ -104,6 +106,16 @@ class BaseClient:
         self.retry_delay = retry_delay
         self.timeout = timeout
         self._owns_auth = owns_auth
+
+    def _resolve_agent_id(self, agent_id: int | None) -> int:
+        """Return the given *agent_id*, falling back to ``self.agent_id``."""
+        resolved = agent_id or self.agent_id
+        if resolved is None:
+            raise ValueError(
+                "agent_id must be provided either as a method argument "
+                "or set on the client instance."
+            )
+        return resolved
 
     @property
     def token(self) -> str | None:

--- a/pydoover/api/data/_iterators.py
+++ b/pydoover/api/data/_iterators.py
@@ -20,18 +20,19 @@ class AsyncMessageIterator:
 
     Usage::
 
-        async for message in client.iter_messages(agent_id, channel_name):
+        async for message in client.iter_messages("my_channel", agent_id=123):
             ...
 
         # Or load all into memory:
-        messages = await client.iter_messages(agent_id, channel_name).collect()
+        messages = await client.iter_messages("my_channel", agent_id=123).collect()
     """
 
     def __init__(
         self,
         client: AsyncDataClient,
-        agent_id: int,
         channel_name: str,
+        *,
+        agent_id: int | None = None,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         field_names: list[str] | None = None,
@@ -39,8 +40,8 @@ class AsyncMessageIterator:
         page_size: int = DEFAULT_PAGE_SIZE,
     ):
         self._client = client
-        self._agent_id = agent_id
         self._channel_name = channel_name
+        self._agent_id = agent_id
         self._before = _to_snowflake(before)
         self._after = _to_snowflake(after)
         self._field_names = field_names
@@ -63,12 +64,12 @@ class AsyncMessageIterator:
 
     async def _fetch_page(self):
         page = await self._client.list_messages(
-            self._agent_id,
             self._channel_name,
             before=self._before,
             after=self._after,
             limit=self._page_size,
             field_names=self._field_names,
+            agent_id=self._agent_id,
             organisation_id=self._organisation_id,
         )
         if not page or len(page) < self._page_size:
@@ -90,18 +91,19 @@ class MessageIterator:
 
     Usage::
 
-        for message in client.iter_messages(agent_id, channel_name):
+        for message in client.iter_messages("my_channel", agent_id=123):
             ...
 
         # Or load all into memory:
-        messages = client.iter_messages(agent_id, channel_name).collect()
+        messages = client.iter_messages("my_channel", agent_id=123).collect()
     """
 
     def __init__(
         self,
         client: DataClient,
-        agent_id: int,
         channel_name: str,
+        *,
+        agent_id: int | None = None,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         field_names: list[str] | None = None,
@@ -109,8 +111,8 @@ class MessageIterator:
         page_size: int = DEFAULT_PAGE_SIZE,
     ):
         self._client = client
-        self._agent_id = agent_id
         self._channel_name = channel_name
+        self._agent_id = agent_id
         self._before = _to_snowflake(before)
         self._after = _to_snowflake(after)
         self._field_names = field_names
@@ -133,12 +135,12 @@ class MessageIterator:
 
     def _fetch_page(self):
         page = self._client.list_messages(
-            self._agent_id,
             self._channel_name,
             before=self._before,
             after=self._after,
             limit=self._page_size,
             field_names=self._field_names,
+            agent_id=self._agent_id,
             organisation_id=self._organisation_id,
         )
         if not page or len(page) < self._page_size:

--- a/pydoover/api/data/_sync.py
+++ b/pydoover/api/data/_sync.py
@@ -5,7 +5,7 @@ Usage::
     from pydoover.api import DataClient
 
     client = DataClient("https://data.doover.com/api", token="...")
-    channel = client.fetch_channel(agent_id, "my_channel")
+    channel = client.fetch_channel("my_channel", agent_id=123)
 """
 
 from __future__ import annotations
@@ -177,11 +177,12 @@ class DataClient(BaseClient):
 
     def list_channels(
         self,
-        agent_id: int,
         include_aggregate: bool = True,
         include_daily_summaries: bool = True,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Channel]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels",
@@ -195,11 +196,12 @@ class DataClient(BaseClient):
 
     def fetch_channel(
         self,
-        agent_id: int,
         channel_name: str,
         include_aggregate: bool = True,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Channel:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}",
@@ -210,14 +212,15 @@ class DataClient(BaseClient):
 
     def create_channel(
         self,
-        agent_id: int,
         channel_name: str,
         is_private: bool = False,
         message_schema: dict | None = None,
         aggregate_schema: dict | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> int:
         """Create a channel. Returns the new channel's snowflake ID."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"is_private": is_private}
         if message_schema is not None:
             payload["message_schema"] = message_schema
@@ -233,13 +236,14 @@ class DataClient(BaseClient):
 
     def put_channel(
         self,
-        agent_id: int,
         channel_name: str,
         is_private: bool,
         message_schema: dict | None = None,
         aggregate_schema: dict | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Channel:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"is_private": is_private}
         if message_schema is not None:
             payload["message_schema"] = message_schema
@@ -255,13 +259,14 @@ class DataClient(BaseClient):
 
     def list_data_series(
         self,
-        agent_id: int,
         field_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> dict[str, Any]:
+        agent_id = self._resolve_agent_id(agent_id)
         return self._request(
             "GET",
             f"/agents/{agent_id}/data_series",
@@ -278,14 +283,15 @@ class DataClient(BaseClient):
 
     def list_messages(
         self,
-        agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
         field_names: list[str] | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Message]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages",
@@ -301,23 +307,24 @@ class DataClient(BaseClient):
 
     def iter_messages(
         self,
-        agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         field_names: list[str] | None = None,
-        organisation_id: int | None = None,
         page_size: int = 50,
+        agent_id: int | None = None,
+        organisation_id: int | None = None,
     ) -> MessageIterator:
         """Return a paginating iterator over channel messages.
 
         Use as ``for msg in client.iter_messages(...)`` or call
         ``.collect()`` to load all matching messages into a list.
         """
+        agent_id = self._resolve_agent_id(agent_id)
         return MessageIterator(
             self,
-            agent_id,
             channel_name,
+            agent_id=agent_id,
             before=before,
             after=after,
             field_names=field_names,
@@ -327,11 +334,12 @@ class DataClient(BaseClient):
 
     def fetch_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -341,14 +349,15 @@ class DataClient(BaseClient):
 
     def create_message(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
         timestamp: int | None = None,
         files: list[File] | None = None,
         message_id: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {"data": data}
         if timestamp is not None:
             if isinstance(timestamp, datetime):
@@ -371,17 +380,18 @@ class DataClient(BaseClient):
 
     def update_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
         data: dict[str, Any],
-        replace: bool = True,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Message | None:
-        method = "PUT" if replace else "PATCH"
+        agent_id = self._resolve_agent_id(agent_id)
+        method = "PUT" if replace_data else "PATCH"
         result = self._request(
             method,
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -399,11 +409,12 @@ class DataClient(BaseClient):
 
     def delete_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         self._request(
             "DELETE",
             f"/agents/{agent_id}/channels/{channel_name}/messages/{message_id}",
@@ -428,14 +439,15 @@ class DataClient(BaseClient):
 
     def fetch_timeseries(
         self,
-        agent_id: int,
         channel_name: str,
         field_names: list[str],
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> TimeseriesResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/messages/timeseries",
@@ -453,10 +465,11 @@ class DataClient(BaseClient):
 
     def fetch_channel_aggregate(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Aggregate:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/aggregate",
@@ -466,17 +479,18 @@ class DataClient(BaseClient):
 
     def update_channel_aggregate(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
-        replace: bool = False,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
         log_update: bool = False,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Aggregate | None:
-        method = "PUT" if replace else "PATCH"
+        agent_id = self._resolve_agent_id(agent_id)
+        method = "PUT" if replace_data else "PATCH"
         result = self._request(
             method,
             f"/agents/{agent_id}/channels/{channel_name}/aggregate",
@@ -495,12 +509,13 @@ class DataClient(BaseClient):
 
     def fetch_channel_aggregate_attachment(
         self,
-        agent_id: int,
         channel_name: str,
         attachment_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> bytes:
         """Download an aggregate attachment. Follows the redirect to S3."""
+        agent_id = self._resolve_agent_id(agent_id)
         self.auth.ensure_token()
         url = self._build_url(
             f"/agents/{agent_id}/channels/{channel_name}"
@@ -559,10 +574,11 @@ class DataClient(BaseClient):
 
     def list_alarms(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[Alarm]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/alarms",
@@ -572,11 +588,12 @@ class DataClient(BaseClient):
 
     def fetch_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/alarms/{alarm_id}",
@@ -586,7 +603,6 @@ class DataClient(BaseClient):
 
     def create_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         name: str,
         key: str,
@@ -595,8 +611,10 @@ class DataClient(BaseClient):
         description: str = "",
         enabled: bool = True,
         expiry_mins: float | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "key": key,
@@ -617,7 +635,6 @@ class DataClient(BaseClient):
 
     def put_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
         name: str,
@@ -627,8 +644,10 @@ class DataClient(BaseClient):
         description: str = "",
         enabled: bool = True,
         expiry_mins: float | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "key": key,
@@ -649,7 +668,6 @@ class DataClient(BaseClient):
 
     def update_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
         name: str | None = None,
@@ -659,8 +677,10 @@ class DataClient(BaseClient):
         description: str | None = None,
         enabled: bool | None = None,
         expiry_mins: float | None | Unset = UNSET,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> Alarm:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -686,11 +706,12 @@ class DataClient(BaseClient):
 
     def delete_alarm(
         self,
-        agent_id: int,
         channel_name: str,
         alarm_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         self._request(
             "DELETE",
             f"/agents/{agent_id}/channels/{channel_name}/alarms/{alarm_id}",
@@ -701,9 +722,10 @@ class DataClient(BaseClient):
 
     def list_connections(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionDetail]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections",
@@ -725,13 +747,14 @@ class DataClient(BaseClient):
 
     def fetch_connection_history(
         self,
-        agent_id: int,
         default_connection: bool,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionDetail]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections/history",
@@ -747,14 +770,15 @@ class DataClient(BaseClient):
 
     def fetch_subscription_history(
         self,
-        agent_id: int,
         channel_agent_id: int,
         channel_name: str,
         before: int | datetime | None = None,
         after: int | datetime | None = None,
         limit: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionSubscriptionLog]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/wss_connections/subscriptions/history",
@@ -772,10 +796,11 @@ class DataClient(BaseClient):
 
     def fetch_channel_subscriptions(
         self,
-        agent_id: int,
         channel_name: str,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[ConnectionSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/channels/{channel_name}/subscriptions",
@@ -787,9 +812,10 @@ class DataClient(BaseClient):
 
     def fetch_notifications(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> AgentNotificationResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/notifications",
@@ -799,10 +825,11 @@ class DataClient(BaseClient):
 
     def list_notification_endpoints(
         self,
-        agent_id: int,
         name: str | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationEndpoint]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/notifications/endpoints",
@@ -813,15 +840,16 @@ class DataClient(BaseClient):
 
     def create_notification_endpoint(
         self,
-        agent_id: int,
         name: str,
         type: NotificationType | int,
         extra_data: dict[str, Any],
         default: bool,
         priority: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> int:
         """Create a notification endpoint. Returns the new endpoint's snowflake ID."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "name": name,
             "type": NotificationType(type).value,
@@ -840,13 +868,14 @@ class DataClient(BaseClient):
 
     def update_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
         name: str | None = None,
         extra_data: dict[str, Any] | None = None,
         priority: int | None | Unset = UNSET,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -863,10 +892,11 @@ class DataClient(BaseClient):
 
     def delete_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/endpoints/{endpoint_id}",
@@ -875,10 +905,11 @@ class DataClient(BaseClient):
 
     def test_notification_endpoint(
         self,
-        agent_id: int,
         endpoint_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> bool:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "POST",
             f"/agents/{agent_id}/notifications/endpoints/{endpoint_id}/test",
@@ -888,10 +919,11 @@ class DataClient(BaseClient):
 
     def list_notification_subscriptions(
         self,
-        agent_id: int,
         subscribed_to: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscriptions",
@@ -902,14 +934,15 @@ class DataClient(BaseClient):
 
     def create_notification_subscription(
         self,
-        agent_id: int,
         subscribe_to: int,
         severity: NotificationSeverity | int,
         topic_filter: list[str],
         endpoint_id: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[dict[str, int]]:
         """Returns a list of created subscriptions, each with ``id`` and ``endpoint_id``."""
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "subscribe_to": str(subscribe_to),
             "severity": NotificationSeverity(severity).value,
@@ -930,12 +963,13 @@ class DataClient(BaseClient):
 
     def update_notification_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
         severity: NotificationSeverity | int | None = None,
         topic_filter: list[str] | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {}
         if severity is not None:
             payload["severity"] = NotificationSeverity(severity).value
@@ -950,10 +984,11 @@ class DataClient(BaseClient):
 
     def delete_notification_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/subscriptions/{subscription_id}",
@@ -962,10 +997,11 @@ class DataClient(BaseClient):
 
     def list_default_notification_subscriptions(
         self,
-        agent_id: int,
         subscribed_to: int | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscriptions/default",
@@ -976,10 +1012,11 @@ class DataClient(BaseClient):
 
     def delete_default_notification_subscription(
         self,
-        agent_id: int,
         subscribed_to: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         self._request(
             "DELETE",
             f"/agents/{agent_id}/notifications/subscriptions/default/{subscribed_to}",
@@ -988,9 +1025,10 @@ class DataClient(BaseClient):
 
     def list_notification_subscribers(
         self,
-        agent_id: int,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> list[NotificationSubscription]:
+        agent_id = self._resolve_agent_id(agent_id)
         data = self._request(
             "GET",
             f"/agents/{agent_id}/notifications/subscribers",
@@ -1048,13 +1086,14 @@ class DataClient(BaseClient):
 
     def put_schedule(
         self,
-        agent_id: int,
         schedule_id: int,
         app_key: str,
         permissions: list[dict[str, str]],
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> ProcessorTokenResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "app_key": app_key,
             "permissions": permissions,
@@ -1071,14 +1110,15 @@ class DataClient(BaseClient):
 
     def put_subscription(
         self,
-        agent_id: int,
         subscription_id: int,
         subscription_arn: str,
         app_key: str,
         permissions: list[dict[str, str]],
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "subscription_arn": subscription_arn,
             "app_key": app_key,
@@ -1095,7 +1135,6 @@ class DataClient(BaseClient):
 
     def create_ingestion_endpoint(
         self,
-        agent_id: int,
         ingestion_id: int,
         lambda_arn: str,
         cidr_ranges: list[str],
@@ -1107,8 +1146,10 @@ class DataClient(BaseClient):
         never_replace_token: bool = False,
         mini_token: bool = False,
         is_org: bool | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ) -> ProcessorTokenResponse:
+        agent_id = self._resolve_agent_id(agent_id)
         payload: dict[str, Any] = {
             "lambda_arn": lambda_arn,
             "cidr_ranges": cidr_ranges,

--- a/pydoover/docker/application.py
+++ b/pydoover/docker/application.py
@@ -150,7 +150,7 @@ class Application:
 
         self._ready = asyncio.Event()
 
-        self.rpc = RPCManager(self.device_agent)
+        self.rpc = RPCManager(self.device_agent, app_key)
         self.ui_manager = UICommandsManager(self.device_agent)
 
         self.app_key = app_key
@@ -1260,6 +1260,7 @@ def run_app(
         app.tag_manager,
         app.tags,
         app.ui,
+        app.rpc,
     ):
         if inst is not None:
             inst.app_key = app_key

--- a/pydoover/processor/application.py
+++ b/pydoover/processor/application.py
@@ -380,7 +380,7 @@ class Application:
         """
         if self.agent_id is None:
             raise RuntimeError("Agent ID has not been initialized.")
-        return await self.api.fetch_channel(self.agent_id, channel_name)
+        return await self.api.fetch_channel(channel_name)
 
     async def get_tag(self, key: str, default: Any = None):
         if self.tag_manager is None:

--- a/pydoover/processor/data_client.py
+++ b/pydoover/processor/data_client.py
@@ -25,7 +25,6 @@ class ProcessorDataClient(AsyncDataClient):
 
     def __init__(self, base_url: str):
         super().__init__(base_url)
-        self.agent_id: int | None = None
 
         self.has_persistent_connection = lambda: False
         self.is_processor_v2 = True
@@ -64,93 +63,93 @@ class ProcessorDataClient(AsyncDataClient):
 
     async def create_message(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
         timestamp: int | None = None,
         files: list[File] | None = None,
-        organisation_id: int | None = None,
         allow_invoking_channel: bool = False,
+        agent_id: int | None = None,
+        organisation_id: int | None = None,
     ) -> Message:
         if channel_name == self._invoking_channel_name:
             self._check_invoking_channel(channel_name, data, allow_invoking_channel)
 
         return await super().create_message(
-            agent_id,
             channel_name,
             data=data,
             timestamp=timestamp,
             files=files,
-            organisation_id=organisation_id or self.organisation_id,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
 
     async def update_channel_aggregate(
         self,
-        agent_id: int,
         channel_name: str,
         data: dict[str, Any],
-        replace: bool = False,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
         log_update: bool = False,
-        organisation_id: int | None = None,
         allow_invoking_channel: bool = False,
+        agent_id: int | None = None,
+        organisation_id: int | None = None,
     ) -> Aggregate | None:
         if channel_name == self._invoking_channel_name:
             self._check_invoking_channel(channel_name, data, allow_invoking_channel)
 
         return await super().update_channel_aggregate(
-            agent_id,
             channel_name,
             data,
-            replace=replace,
+            replace_data=replace_data,
             files=files,
             suppress_response=suppress_response,
             clear_attachments=clear_attachments,
             log_update=log_update,
-            organisation_id=organisation_id or self.organisation_id,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
 
     async def update_message(
         self,
-        agent_id: int,
         channel_name: str,
         message_id: int,
         data: dict[str, Any],
-        replace: bool = True,
+        replace_data: bool = False,
         files: list[File] | None = None,
         suppress_response: bool = False,
         clear_attachments: bool = False,
-        organisation_id: int | None = None,
         allow_invoking_channel: bool = False,
+        agent_id: int | None = None,
+        organisation_id: int | None = None,
     ) -> Message | None:
         if channel_name == self._invoking_channel_name:
             self._check_invoking_channel(channel_name, data, allow_invoking_channel)
 
         return await super().update_message(
-            agent_id,
             channel_name,
             message_id,
             data=data,
-            replace=replace,
+            replace_data=replace_data,
             files=files,
             suppress_response=suppress_response,
             clear_attachments=clear_attachments,
-            organisation_id=organisation_id or self.organisation_id,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
 
     # -- Connection helpers --------------------------------------------------
 
     async def ping_connection_at(
         self,
-        agent_id: int,
         online_at: datetime,
         connection_status: ConnectionStatus,
         determination: ConnectionDetermination,
         ping_at: datetime | None = None,
         user_agent: str | None = None,
         ip_address: str | None = None,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
         user_agent = user_agent or "pydoover-processor, aiohttp"
@@ -174,37 +173,35 @@ class ProcessorDataClient(AsyncDataClient):
             "determination": determination.value,
         }
 
-        org = organisation_id or self.organisation_id
         await self.create_message(
-            agent_id,
             "doover_connection",
             payload,
-            organisation_id=org,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
         await self.update_channel_aggregate(
-            agent_id,
             "doover_connection",
             payload,
-            organisation_id=org,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
 
     async def update_connection_config(
         self,
-        agent_id: int,
         config: ConnectionConfig,
+        agent_id: int | None = None,
         organisation_id: int | None = None,
     ):
         payload = {"config": config.to_dict()}
-        org = organisation_id or self.organisation_id
         await self.create_message(
-            agent_id,
             "doover_connection",
             payload,
-            organisation_id=org,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )
         await self.update_channel_aggregate(
-            agent_id,
             "doover_connection",
             payload,
-            organisation_id=org,
+            agent_id=agent_id,
+            organisation_id=organisation_id,
         )

--- a/pydoover/reports/application.py
+++ b/pydoover/reports/application.py
@@ -16,7 +16,7 @@ from ..models import (
     DeploymentEvent,
     ScheduleEvent,
 )
-from ..cloud.processor.application import Application as ApplicationBase
+from ..processor.application import Application as ApplicationBase
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +87,6 @@ class Application(ApplicationBase):
 
         try:
             data = await self.api.create_message(
-                self.agent_id,
                 "reports",
                 self._report_metadata,
                 organisation_id=self.agent_id,
@@ -190,7 +189,6 @@ class Application(ApplicationBase):
 
         try:
             await self.api.update_message(
-                self.agent_id,
                 "reports",
                 self._report_id,
                 self._report_metadata,
@@ -202,7 +200,6 @@ class Application(ApplicationBase):
             try:
                 self._report_metadata["status"] = "Failed"
                 await self.api.update_message(
-                    self.agent_id,
                     "reports",
                     self._report_id,
                     self._report_metadata,

--- a/pydoover/rpc.py
+++ b/pydoover/rpc.py
@@ -95,17 +95,41 @@ class RPCContext:
     def channel(self):
         return self.message.channel
 
-    async def acknowledge(self):
-        await self._update_fn(
-            self.channel.name, self.message.id, {"response": {"status": "acknowledged"}}
-        )
+    def _message_data_with_status(self, status: dict[str, Any]) -> dict[str, Any]:
+        data = dict(self.message.data)
+        data["status"] = status
+        data.setdefault("response", {})
+        return data
 
-    async def defer(self, seconds: float):
-        until = datetime.now(tz=timezone.utc) + timedelta(seconds=seconds)
+    async def acknowledge(self):
         await self._update_fn(
             self.channel.name,
             self.message.id,
-            {"response": {"status": "deferred", "until": until}},
+            self._message_data_with_status(
+                {
+                    "code": "acknowledged",
+                    "message": {
+                        "timestamp": int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+                    },
+                }
+            ),
+        )
+
+    async def defer(self, seconds: float):
+        now = datetime.now(tz=timezone.utc)
+        until = now + timedelta(seconds=seconds)
+        await self._update_fn(
+            self.channel.name,
+            self.message.id,
+            self._message_data_with_status(
+                {
+                    "code": "deferred",
+                    "message": {
+                        "until": int(until.timestamp() * 1000),
+                        "at": int(now.timestamp() * 1000),
+                    },
+                }
+            ),
         )
 
 
@@ -123,7 +147,7 @@ class RPCManager:
         The application instance this manager is attached to.
     """
 
-    def __init__(self, api: Union["DeviceAgentInterface", "AsyncDataClient"]):
+    def __init__(self, api: Union["DeviceAgentInterface"]):
         self.api = api
         # (channel_name, method_name) -> (parser, handler)
         self._handlers: dict[tuple[str, str], tuple[Callable, Callable]] = {}
@@ -214,7 +238,15 @@ class RPCManager:
         """
         self._ensure_subscribed(channel)
 
-        data = {"method": method, "request": params or {}}
+        data = {
+            "type": "rpc",
+            "method": method,
+            "request": params or {},
+            "status": {"code": "sent"},
+            "response": {},
+        }
+        if getattr(self.api, "app_key", None):
+            data["app_key"] = self.api.app_key
         message_id = await self.api.create_message(channel, data)
 
         loop = asyncio.get_running_loop()
@@ -310,33 +342,25 @@ class RPCManager:
             result = await method_handler(ctx, payload)
         except RPCError as e:
             if can_respond:
-                await self._send_error(
-                    channel_name, event.message.id, e.code, e.message
-                )
+                await self._send_error(event.message, e.code, e.message)
         except Exception as e:
             log.error(
                 f"Unhandled exception in RPC handler '{method_handler}': {e}",
                 exc_info=e,
             )
             if can_respond:
-                await self._send_error(
-                    channel_name, event.message.id, "INTERNAL_ERROR", str(e)
-                )
+                await self._send_error(event.message, "INTERNAL_ERROR", str(e))
         else:
             if result is None:
                 result = {}
 
             if can_respond:
-                await self._send_result(
-                    channel_name,
-                    event.message.id,
-                    {"status": "success", "result": result},
-                )
+                await self._send_result(event.message, result)
 
     def _handle_response(self, event: MessageUpdateEvent) -> None:
         """Resolve a pending future if this update is an RPC response."""
         try:
-            response = event.message.data["response"]
+            status = event.message.data["status"]
         except KeyError:
             return
 
@@ -344,36 +368,48 @@ class RPCManager:
         if future is None or future.done():
             return
 
-        # Non-terminal status updates (e.g. "acknowledged") don't resolve
-        if (
-            "status" in response
-            and "result" not in response
-            and "error" not in response
-        ):
+        status_code = status.get("code")
+        if status_code in {"sent", "acknowledged", "deferred", "pending"}:
             return
 
-        if "error" in response:
-            err = response["error"]
+        if status_code == "error":
+            err = status.get("message", "")
+            if isinstance(err, dict):
+                code = err.get("code", "UNKNOWN")
+                message = err.get("message", "")
+            else:
+                code = "UNKNOWN"
+                message = err
             future.set_exception(
-                RPCError(err.get("code", "UNKNOWN"), err.get("message", ""))
+                RPCError(code, message)
             )
-        elif "result" in response:
-            future.set_result(response["result"])
+        elif status_code == "success":
+            future.set_result(event.message.data.get("response", {}))
 
     # -- response helpers ---------------------------------------------------
 
-    async def _send_result(
-        self, channel_name: str, message_id: int, result: dict
-    ) -> None:
-        await self.api.update_message(channel_name, message_id, {"response": result})
+    async def _send_result(self, message: Message, response: dict) -> None:
+        data = dict(message.data)
+        data["status"] = {"code": "success"}
+        data["response"] = response
+        await self.api.update_message(message.channel.name, message.id, data)
 
     async def _send_error(
-        self, channel_name: str, message_id: int, code: str, message: str
+        self,
+        request_message: Message,
+        code: str,
+        error_message: str | dict[str, Any],
     ) -> None:
+        data = dict(request_message.data)
+        data["status"] = {
+            "code": "error",
+            "message": {"code": code, "message": error_message},
+        }
+        data["response"] = {}
         await self.api.update_message(
-            channel_name,
-            message_id,
-            {"response": {"status": "error", "code": code, "message": message}},
+            request_message.channel.name,
+            request_message.id,
+            data,
         )
 
     # -- static helpers for processor usage ---------------------------------
@@ -409,5 +445,11 @@ class RPCManager:
         int
             The created message ID.
         """
-        data = {"request": params or {}, "method": method}
+        data = {
+            "type": "rpc",
+            "request": params or {},
+            "method": method,
+            "status": {"code": "sent"},
+            "response": {},
+        }
         return await client.create_message(agent_id, channel, data)

--- a/pydoover/rpc.py
+++ b/pydoover/rpc.py
@@ -22,7 +22,6 @@ from .models.data import (
 
 if TYPE_CHECKING:
     from .docker.application import DeviceAgentInterface
-    from .api import AsyncDataClient
 
 log = logging.getLogger(__name__)
 

--- a/pydoover/rpc.py
+++ b/pydoover/rpc.py
@@ -22,6 +22,7 @@ from .models.data import (
 
 if TYPE_CHECKING:
     from .docker.application import DeviceAgentInterface
+    from .api.data import AsyncDataClient
 
 log = logging.getLogger(__name__)
 
@@ -94,42 +95,31 @@ class RPCContext:
     def channel(self):
         return self.message.channel
 
-    def _message_data_with_status(self, status: dict[str, Any]) -> dict[str, Any]:
-        data = dict(self.message.data)
-        data["status"] = status
-        data.setdefault("response", {})
-        return data
-
     async def acknowledge(self):
-        await self._update_fn(
-            self.channel.name,
-            self.message.id,
-            self._message_data_with_status(
-                {
-                    "code": "acknowledged",
-                    "message": {
-                        "timestamp": int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-                    },
-                }
-            ),
-        )
+        # fixme: maybe these should be objects...
+        payload = {
+            "status": {
+                "code": "acknowledged",
+                "message": {
+                    "timestamp": int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+                },
+            }
+        }
+        await self._update_fn(self.channel.name, self.message.id, payload)
 
     async def defer(self, seconds: float):
         now = datetime.now(tz=timezone.utc)
         until = now + timedelta(seconds=seconds)
-        await self._update_fn(
-            self.channel.name,
-            self.message.id,
-            self._message_data_with_status(
-                {
-                    "code": "deferred",
-                    "message": {
-                        "until": int(until.timestamp() * 1000),
-                        "at": int(now.timestamp() * 1000),
-                    },
-                }
-            ),
-        )
+        payload = {
+            "status": {
+                "code": "deferred",
+                "message": {
+                    "until": int(until.timestamp() * 1000),
+                    "at": int(now.timestamp() * 1000),
+                },
+            }
+        }
+        await self._update_fn(self.channel.name, self.message.id, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -144,10 +134,17 @@ class RPCManager:
     ----------
     api : DeviceAgentInterface | AsyncDataClient
         The application instance this manager is attached to.
+    app_key : str | None
+        The application key for this app, used to reject messages not intended for this app.
     """
 
-    def __init__(self, api: Union["DeviceAgentInterface"]):
+    def __init__(
+        self,
+        api: Union["DeviceAgentInterface", "AsyncDataClient"],
+        app_key: str | None = None,
+    ):
         self.api = api
+        self.app_key = app_key
         # (channel_name, method_name) -> (parser, handler)
         self._handlers: dict[tuple[str, str], tuple[Callable, Callable]] = {}
         self._re_handlers: list[tuple[str, re.Pattern, Callable, Callable]] = []
@@ -208,6 +205,7 @@ class RPCManager:
         method: str,
         params: dict[str, Any] | None = None,
         channel: str = DEFAULT_CHANNEL,
+        app_key: str | None = None,
         timeout: float = 30.0,
     ) -> dict:
         """Make an RPC call and wait for the response.
@@ -244,8 +242,8 @@ class RPCManager:
             "status": {"code": "sent"},
             "response": {},
         }
-        if getattr(self.api, "app_key", None):
-            data["app_key"] = self.api.app_key
+        if app_key:
+            data["app_key"] = app_key
         message_id = await self.api.create_message(channel, data)
 
         loop = asyncio.get_running_loop()
@@ -308,9 +306,9 @@ class RPCManager:
         except KeyError:
             pass
         else:
-            if app_key != self.api.app_key:
+            if app_key != self.app_key:
                 log.debug(
-                    f"Skipping RPC request for app_key={app_key!r} (ours={self.api.app_key!r})"
+                    f"Skipping RPC request for app_key={app_key!r} (ours={self.app_key!r})"
                 )
                 return
 
@@ -361,6 +359,7 @@ class RPCManager:
         try:
             status = event.message.data["status"]
         except KeyError:
+            log.debug("Failed to get status from RPC message. Ignoring.")
             return
 
         future = self._pending_calls.get(event.message.id)
@@ -368,7 +367,7 @@ class RPCManager:
             return
 
         status_code = status.get("code")
-        if status_code in {"sent", "acknowledged", "deferred", "pending"}:
+        if status_code in ("sent", "acknowledged", "deferred", "pending"):
             return
 
         if status_code == "error":
@@ -379,18 +378,19 @@ class RPCManager:
             else:
                 code = "UNKNOWN"
                 message = err
-            future.set_exception(
-                RPCError(code, message)
-            )
+            future.set_exception(RPCError(code, message))
         elif status_code == "success":
             future.set_result(event.message.data.get("response", {}))
 
     # -- response helpers ---------------------------------------------------
 
     async def _send_result(self, message: Message, response: dict) -> None:
-        data = dict(message.data)
-        data["status"] = {"code": "success"}
-        data["response"] = response
+        data = {
+            "status": {
+                "code": "success",
+            },
+            "response": response,
+        }
         await self.api.update_message(message.channel.name, message.id, data)
 
     async def _send_error(
@@ -399,12 +399,13 @@ class RPCManager:
         code: str,
         error_message: str | dict[str, Any],
     ) -> None:
-        data = dict(request_message.data)
-        data["status"] = {
-            "code": "error",
-            "message": {"code": code, "message": error_message},
+        data = {
+            "status": {
+                "code": "error",
+                "message": {"code": code, "message": error_message},
+            },
+            "response": {},
         }
-        data["response"] = {}
         await self.api.update_message(
             request_message.channel.name,
             request_message.id,

--- a/pydoover/rpc.py
+++ b/pydoover/rpc.py
@@ -452,4 +452,4 @@ class RPCManager:
             "status": {"code": "sent"},
             "response": {},
         }
-        return await client.create_message(agent_id, channel, data)
+        return await client.create_message(channel, data, agent_id=agent_id)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -140,22 +140,11 @@ class TestRPCContext:
 
         await ctx.acknowledge()
 
-        assert updates == [
-            (
-                "control",
-                55,
-                {
-                    "type": "rpc",
-                    "method": "slow_op",
-                    "request": {},
-                    "status": {
-                        "code": "acknowledged",
-                        "message": {"timestamp": pytest.approx(updates[0][2]["status"]["message"]["timestamp"])},
-                    },
-                    "response": {},
-                },
-            ),
-        ]
+        assert len(updates) == 1
+        assert updates[0][0] == "control"
+        assert updates[0][1] == 55
+        assert updates[0][2]["status"]["code"] == "acknowledged"
+        assert isinstance(updates[0][2]["status"]["message"]["timestamp"], int)
 
     @pytest.mark.asyncio
     async def test_defer_sets_until_and_at_timestamps(self):
@@ -220,13 +209,8 @@ class TestRPCManagerIntegration:
         await app.fire_event("test_channel", _make_request_event("ping", {"x": 1}))
 
         assert calls == [("test_channel", {"x": 1})]
-        assert app.messages[100]["data"] == {
-            "type": "rpc",
-            "method": "ping",
-            "request": {"x": 1},
-            "status": {"code": "success"},
-            "response": {"pong": True},
-        }
+        assert app.messages[100]["data"]["status"] == {"code": "success"}
+        assert app.messages[100]["data"]["response"] == {"pong": True}
 
     @pytest.mark.asyncio
     async def test_handler_rpc_error(self):
@@ -242,19 +226,10 @@ class TestRPCManagerIntegration:
         manager.register_handlers(HandlerSet())
         await app.fire_event("test_channel", _make_request_event("check"))
 
-        assert app.messages[100]["data"] == {
-            "type": "rpc",
-            "method": "check",
-            "request": {},
-            "status": {
-                "code": "error",
-                "message": {
-                    "code": "OFFLINE",
-                    "message": "Device is offline",
-                },
-            },
-            "response": {},
-        }
+        status = app.messages[100]["data"]["status"]
+        assert status["code"] == "error"
+        assert status["message"]["code"] == "OFFLINE"
+        assert status["message"]["message"] == "Device is offline"
 
     @pytest.mark.asyncio
     async def test_handler_unhandled_exception(self):
@@ -289,14 +264,9 @@ class TestRPCManagerIntegration:
         await asyncio.sleep(0)
 
         assert 1000 in manager._pending_calls
-        assert app.messages[1000]["data"] == {
-            "type": "rpc",
-            "method": "ping",
-            "request": {"x": 1},
-            "status": {"code": "sent"},
-            "response": {},
-            "app_key": "test_app",
-        }
+        assert app.messages[1000]["data"]["method"] == "ping"
+        assert app.messages[1000]["data"]["request"] == {"x": 1}
+        assert app.messages[1000]["data"]["status"] == {"code": "sent"}
 
         await app.fire_event(
             "test_channel",
@@ -351,7 +321,9 @@ class TestRPCManagerIntegration:
             data={"normal": "message"},
             attachments=[],
         )
-        event = MessageCreateEvent(channel=_make_channel("test_channel"), message=message)
+        event = MessageCreateEvent(
+            channel=_make_channel("test_channel"), message=message
+        )
 
         await app.fire_event("test_channel", event)
 
@@ -404,7 +376,9 @@ class TestRPCManagerIntegration:
         manager.register_handlers(HandlerSet())
         manager.subscribe("other")
 
-        await app.fire_event("control", _make_request_event("ping", channel_name="control"))
+        await app.fire_event(
+            "control", _make_request_event("ping", channel_name="control")
+        )
         await app.fire_event("other", _make_request_event("ping", channel_name="other"))
 
         assert calls == ["control"]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,6 +1,5 @@
 import asyncio
 import re
-from datetime import datetime
 
 import pytest
 
@@ -28,14 +27,21 @@ def _make_request_event(
         id=message_id,
         author_id=42,
         channel=channel,
-        data={"type": "rpc", "method": method, "request": payload or {}},
+        data={
+            "type": "rpc",
+            "method": method,
+            "request": payload or {},
+            "status": {"code": "sent"},
+            "response": {},
+        },
         attachments=[],
     )
     return MessageCreateEvent(channel=channel, message=message)
 
 
 def _make_response_event(
-    response: dict,
+    status: dict,
+    response: dict | None = None,
     message_id: int = 100,
     channel_name: str = "test_channel",
 ) -> MessageUpdateEvent:
@@ -44,7 +50,7 @@ def _make_response_event(
         id=message_id,
         author_id=99,
         channel=channel,
-        data={"response": response},
+        data={"status": status, "response": response or {}},
         attachments=[],
     )
     return MessageUpdateEvent(
@@ -135,11 +141,24 @@ class TestRPCContext:
         await ctx.acknowledge()
 
         assert updates == [
-            ("control", 55, {"response": {"status": "acknowledged"}}),
+            (
+                "control",
+                55,
+                {
+                    "type": "rpc",
+                    "method": "slow_op",
+                    "request": {},
+                    "status": {
+                        "code": "acknowledged",
+                        "message": {"timestamp": pytest.approx(updates[0][2]["status"]["message"]["timestamp"])},
+                    },
+                    "response": {},
+                },
+            ),
         ]
 
     @pytest.mark.asyncio
-    async def test_defer_sets_datetime_until(self):
+    async def test_defer_sets_until_and_at_timestamps(self):
         updates = []
 
         async def update_fn(channel_name, message_id, data):
@@ -159,9 +178,11 @@ class TestRPCContext:
 
         await ctx.defer(5)
 
-        response = updates[0][2]["response"]
-        assert response["status"] == "deferred"
-        assert isinstance(response["until"], datetime)
+        status = updates[0][2]["status"]
+        assert status["code"] == "deferred"
+        assert isinstance(status["message"]["until"], int)
+        assert isinstance(status["message"]["at"], int)
+        assert status["message"]["until"] >= status["message"]["at"]
 
 
 class TestRegisterHandlers:
@@ -200,7 +221,11 @@ class TestRPCManagerIntegration:
 
         assert calls == [("test_channel", {"x": 1})]
         assert app.messages[100]["data"] == {
-            "response": {"status": "success", "result": {"pong": True}}
+            "type": "rpc",
+            "method": "ping",
+            "request": {"x": 1},
+            "status": {"code": "success"},
+            "response": {"pong": True},
         }
 
     @pytest.mark.asyncio
@@ -218,11 +243,17 @@ class TestRPCManagerIntegration:
         await app.fire_event("test_channel", _make_request_event("check"))
 
         assert app.messages[100]["data"] == {
-            "response": {
-                "status": "error",
-                "code": "OFFLINE",
-                "message": "Device is offline",
-            }
+            "type": "rpc",
+            "method": "check",
+            "request": {},
+            "status": {
+                "code": "error",
+                "message": {
+                    "code": "OFFLINE",
+                    "message": "Device is offline",
+                },
+            },
+            "response": {},
         }
 
     @pytest.mark.asyncio
@@ -239,10 +270,10 @@ class TestRPCManagerIntegration:
         manager.register_handlers(HandlerSet())
         await app.fire_event("test_channel", _make_request_event("boom"))
 
-        response = app.messages[100]["data"]["response"]
-        assert response["status"] == "error"
-        assert response["code"] == "INTERNAL_ERROR"
-        assert "something broke" in response["message"]
+        status = app.messages[100]["data"]["status"]
+        assert status["code"] == "error"
+        assert status["message"]["code"] == "INTERNAL_ERROR"
+        assert "something broke" in status["message"]["message"]
 
     @pytest.mark.asyncio
     async def test_call_resolves_on_response(self):
@@ -259,14 +290,19 @@ class TestRPCManagerIntegration:
 
         assert 1000 in manager._pending_calls
         assert app.messages[1000]["data"] == {
+            "type": "rpc",
             "method": "ping",
             "request": {"x": 1},
+            "status": {"code": "sent"},
+            "response": {},
+            "app_key": "test_app",
         }
 
         await app.fire_event(
             "test_channel",
             _make_response_event(
-                {"status": "success", "result": {"pong": True}},
+                {"code": "success"},
+                {"pong": True},
                 message_id=1000,
             ),
         )
@@ -294,10 +330,7 @@ class TestRPCManagerIntegration:
         await app.fire_event(
             "test_channel",
             _make_response_event(
-                {
-                    "status": "error",
-                    "error": {"code": "BAD", "message": "nope"},
-                },
+                {"code": "error", "message": {"code": "BAD", "message": "nope"}},
                 message_id=1000,
             ),
         )
@@ -336,7 +369,10 @@ class TestRPCManagerIntegration:
 
         await app.fire_event(
             "test_channel",
-            _make_response_event({"status": "acknowledged"}, message_id=1000),
+            _make_response_event(
+                {"code": "acknowledged", "message": {"timestamp": 123}},
+                message_id=1000,
+            ),
         )
 
         assert not manager._pending_calls[1000].done()
@@ -344,7 +380,8 @@ class TestRPCManagerIntegration:
         await app.fire_event(
             "test_channel",
             _make_response_event(
-                {"status": "success", "result": {"done": True}},
+                {"code": "success"},
+                {"done": True},
                 message_id=1000,
             ),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "pydoover"
-version = "0.4.18"
+version = "1.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Changed to new RPC format based on the following typescript definition and fixed some typing bugs

```typescript
type Status<TPending = object> = {
  code: "sent";
} | {
  code: "acknowledged";
  message: {
    timestamp: number;
  }
} | {
  code: "error";
  message: string | object;
} | {
  code: "deferred",
  message: {
    until: number;
    at: number
  }
} | {
  code: "pending",
  message: TPending
} | {
  code: "success"
}

export interface RPCMessageStructure<TRequest = object, TResponse = object, TPending = undefined> {
  app_key?: string;
  method: string;
  request: TRequest;
  status: Status<TPending>;
  response: TResponse;
}
```

