### PR TITLE
Prevent DDA channel stream task from silently dying

### DIFF
--- a/pydoover/docker/device_agent/device_agent.py
+++ b/pydoover/docker/device_agent/device_agent.py
@@ -263,29 +263,44 @@ class DeviceAgentInterface(GRPCInterface):
                         exc_info=e,
                     )
 
-        async for event in self.stream_channel_events(channel_name):
-            # Update internal aggregate state on AggregateUpdate
-            if isinstance(event, AggregateUpdateEvent):
-                self._aggregates[channel_name] = event.aggregate
-                self._synced_channels[channel_name] = True
-                self.last_channel_message_ts[channel_name] = datetime.now(
-                    tz=timezone.utc
+        # Wrap the event loop in a retry loop so any uncaught exception from
+        # stream_channel_events or the dispatch body does not silently kill the
+        # subscription task. Without this, an unexpected error leaves the task
+        # dead and _ensure_stream has no mechanism to restart it, causing
+        # subscriptions to stop firing until the process restarts.
+        while True:
+            try:
+                async for event in self.stream_channel_events(channel_name):
+                    # Update internal aggregate state on AggregateUpdate
+                    if isinstance(event, AggregateUpdateEvent):
+                        self._aggregates[channel_name] = event.aggregate
+                        self._synced_channels[channel_name] = True
+                        self.last_channel_message_ts[channel_name] = datetime.now(
+                            tz=timezone.utc
+                        )
+
+                    # Determine which flag this event corresponds to
+                    event_flag = self._event_type_to_flag(event)
+
+                    # Distribute to matching registered callbacks
+                    for callback, events in self._event_callbacks.get(channel_name, []):
+                        if event_flag is None or event_flag not in events:
+                            continue
+                        try:
+                            asyncio.create_task(callback(event))
+                        except Exception as e:
+                            log.error(
+                                f"Error dispatching event callback for {channel_name}: {e}",
+                                exc_info=e,
+                            )
+            except asyncio.CancelledError:
+                raise
+            except BaseException as e:
+                log.exception(
+                    f"Stream task for {channel_name} crashed, restarting: {e}"
                 )
-
-            # Determine which flag this event corresponds to
-            event_flag = self._event_type_to_flag(event)
-
-            # Distribute to matching registered callbacks
-            for callback, events in self._event_callbacks.get(channel_name, []):
-                if event_flag is None or event_flag not in events:
-                    continue
-                try:
-                    asyncio.create_task(callback(event))
-                except Exception as e:
-                    log.error(
-                        f"Error dispatching event callback for {channel_name}: {e}",
-                        exc_info=e,
-                    )
+                await asyncio.sleep(1)
+                continue
 
     async def stream_channel_events(self, channel_name: str):
         backoff = 1

--- a/pydoover/processor/__init__.py
+++ b/pydoover/processor/__init__.py
@@ -7,5 +7,6 @@ from .config import (
     ExtendedPermissionsConfig as ExtendedPermissionsConfig,
     TimezoneConfig as TimezoneConfig,
     SerialNumberConfig as SerialNumberConfig,
+    EgressChannelConfig as EgressChannelConfig,
 )
 from .handler import run_app as run_app

--- a/pydoover/processor/config.py
+++ b/pydoover/processor/config.py
@@ -184,3 +184,28 @@ class SerialNumberConfig(String):
             name="dv_serial_number",
             **kwargs,
         )
+
+
+class EgressChannelConfig(String):
+    """Egress channel for integrations.
+
+    The integration will subscribe to this channel on all devices associated.
+
+    Generally, you should set a default in the app so users don't have to worry about this.
+    """
+
+    def __init__(
+        self,
+        display_name: str = "Egress Channel",
+        *,
+        description: str = "Channel to subscribe on every device configured.",
+        hidden: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            display_name,
+            description=description,
+            name="dv_egress_channel",
+            hidden=hidden,
+            **kwargs,
+        )

--- a/tests/test_device_agent.py
+++ b/tests/test_device_agent.py
@@ -6,6 +6,7 @@ These tests mock the gRPC layer (make_request / process_response) to verify that
 - The aggregate cache stores and returns Aggregate objects
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -319,7 +320,8 @@ class TestRunChannelStreamSeeding:
         self.dda.wait_until_healthy = mock_healthy
         self.dda.fetch_channel_aggregate = mock_fetch
 
-        await self.dda._run_channel_stream("ch")
+        with pytest.raises(asyncio.CancelledError):
+            await self.dda._run_channel_stream("ch")
 
         assert call_order[0] == "healthy"
         assert call_order[1] == "fetch"
@@ -329,7 +331,8 @@ class TestRunChannelStreamSeeding:
         agg = Aggregate(data={"seeded": True}, attachments=[], last_updated=None)
         self.dda.fetch_channel_aggregate = AsyncMock(return_value=agg)
 
-        await self.dda._run_channel_stream("ch")
+        with pytest.raises(asyncio.CancelledError):
+            await self.dda._run_channel_stream("ch")
 
         assert isinstance(self.dda._aggregates["ch"], Aggregate)
         assert self.dda._aggregates["ch"].data == {"seeded": True}
@@ -344,7 +347,8 @@ class TestRunChannelStreamSeeding:
         )
         self.dda.update_channel_aggregate = AsyncMock(return_value=created_agg)
 
-        await self.dda._run_channel_stream("new_ch")
+        with pytest.raises(asyncio.CancelledError):
+            await self.dda._run_channel_stream("new_ch")
 
         self.dda.update_channel_aggregate.assert_awaited_once_with("new_ch", {})
         assert isinstance(self.dda._aggregates["new_ch"], Aggregate)
@@ -360,7 +364,8 @@ class TestRunChannelStreamSeeding:
             side_effect=HTTPError(500, "Server error")
         )
 
-        await self.dda._run_channel_stream("broken_ch")
+        with pytest.raises(asyncio.CancelledError):
+            await self.dda._run_channel_stream("broken_ch")
 
         assert self.dda._synced_channels["broken_ch"] is True
         assert "broken_ch" not in self.dda._aggregates
@@ -372,12 +377,16 @@ class TestRunChannelStreamSeeding:
             side_effect=DooverAPIError("Connection failed")
         )
 
-        await self.dda._run_channel_stream("err_ch")
+        with pytest.raises(asyncio.CancelledError):
+            await self.dda._run_channel_stream("err_ch")
 
         assert self.dda._synced_channels["err_ch"] is True
         assert "err_ch" not in self.dda._aggregates
 
 
 async def _empty_async_gen():
-    return
-    yield  # make it an async generator
+    # Raise CancelledError to break out of the retry loop in _run_channel_stream;
+    # in production stream_channel_events only exits via cancellation.
+    if False:
+        yield
+    raise asyncio.CancelledError


### PR DESCRIPTION
## Summary
- Wraps the main event loop in `_run_channel_stream` with `while True:` + `try/except BaseException` so any uncaught exception (or buggy subclass of `BaseException` other than `CancelledError`) no longer kills the subscription task.
- `asyncio.CancelledError` is re-raised unchanged, preserving existing shutdown semantics.
- On unexpected failure the loop logs a traceback, sleeps 1s, and reconnects.

## Background
`_ensure_stream` only checks whether `channel_name` is a key in `_stream_tasks` — it does **not** check whether the task is still alive. If `_run_channel_stream` ever raised, the dead `Task` object stayed in the dict forever and no new stream was created, so all tag/channel subscriptions silently stopped firing until the process restarted.

This was observed in production: a sia-injection-controller app stopped receiving `StateWriteTag` updates and remained stuck in the pumping state even though the DDA aggregate was being updated correctly from another app. Restarting the container restored subscription delivery, confirming the task had died.

## Test plan
- [ ] Manual: Kill the DDA mid-stream and verify subscriptions resume when the DDA comes back (previously worked via the existing inner retry in `stream_channel_events`)
- [ ] Manual: Inject a synthetic exception in the dispatch body (e.g. via a faulty callback registration path) and verify the stream recovers instead of dying
- [ ] Regression: Existing unit tests for `DeviceAgentInterface` still pass
- [ ] Observed in field: sia-injection-controller no longer gets stuck after extended uptime when test-bench writes StateWriteTag