### PR TITLE
Update control API client and models

### DIFF
--- a/pydoover/api/control/_async.py
+++ b/pydoover/api/control/_async.py
@@ -181,6 +181,8 @@ class AsyncControlClient(AsyncControlClientGroups, BaseControlClient):
         text = await response.text()
         if not text:
             return None
+        if response_kind == "text":
+            return text
         if response_kind == "raw":
             return json.loads(text)
         data = json.loads(text)

--- a/pydoover/api/control/_generated_async.py
+++ b/pydoover/api/control/_generated_async.py
@@ -1258,7 +1258,7 @@ class DevicesAsyncGroup(_ControlGroupBase[_AsyncControlExecutor]):
             item_schema=None,
         )
 
-    async def installer(self, id: str, organisation_id: int | None = None) -> Any:
+    async def installer(self, id: str, organisation_id: int | None = None) -> str:
         path = f"/devices/{id}/installer/"
         params = None
         return await self._root._execute(
@@ -1270,12 +1270,12 @@ class DevicesAsyncGroup(_ControlGroupBase[_AsyncControlExecutor]):
             body_mode="json",
             binary_fields=None,
             organisation_id=organisation_id,
-            response_kind="raw",
+            response_kind="text",
             response_schema=None,
             item_schema=None,
         )
 
-    async def installer_download(self, id: str, organisation_id: int | None = None) -> Any:
+    async def installer_download(self, id: str, organisation_id: int | None = None) -> bytes:
         path = f"/devices/{id}/installer/download/"
         params = None
         return await self._root._execute(
@@ -1287,7 +1287,7 @@ class DevicesAsyncGroup(_ControlGroupBase[_AsyncControlExecutor]):
             body_mode="json",
             binary_fields=None,
             organisation_id=organisation_id,
-            response_kind="raw",
+            response_kind="bytes",
             response_schema=None,
             item_schema=None,
         )
@@ -6237,4 +6237,3 @@ __all__ = [
     "TunnelsAsyncGroup",
     "UsersAsyncGroup",
 ]
-

--- a/pydoover/api/control/_generated_sync.py
+++ b/pydoover/api/control/_generated_sync.py
@@ -1258,7 +1258,7 @@ class DevicesSyncGroup(_ControlGroupBase[_SyncControlExecutor]):
             item_schema=None,
         )
 
-    def installer(self, id: str, organisation_id: int | None = None) -> Any:
+    def installer(self, id: str, organisation_id: int | None = None) -> str:
         path = f"/devices/{id}/installer/"
         params = None
         return self._root._execute(
@@ -1270,12 +1270,12 @@ class DevicesSyncGroup(_ControlGroupBase[_SyncControlExecutor]):
             body_mode="json",
             binary_fields=None,
             organisation_id=organisation_id,
-            response_kind="raw",
+            response_kind="text",
             response_schema=None,
             item_schema=None,
         )
 
-    def installer_download(self, id: str, organisation_id: int | None = None) -> Any:
+    def installer_download(self, id: str, organisation_id: int | None = None) -> bytes:
         path = f"/devices/{id}/installer/download/"
         params = None
         return self._root._execute(
@@ -1287,7 +1287,7 @@ class DevicesSyncGroup(_ControlGroupBase[_SyncControlExecutor]):
             body_mode="json",
             binary_fields=None,
             organisation_id=organisation_id,
-            response_kind="raw",
+            response_kind="bytes",
             response_schema=None,
             item_schema=None,
         )
@@ -6237,4 +6237,3 @@ __all__ = [
     "TunnelsSyncGroup",
     "UsersSyncGroup",
 ]
-

--- a/pydoover/api/control/_sync.py
+++ b/pydoover/api/control/_sync.py
@@ -147,6 +147,8 @@ class ControlClient(ControlClientGroups, BaseControlClient):
             return response.content
         if not response.content:
             return None
+        if response_kind == "text":
+            return response.text
         if response_kind == "raw":
             return response.json()
         data = response.json()

--- a/scripts/generate_control_api_clients.py
+++ b/scripts/generate_control_api_clients.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run
 
 from __future__ import annotations
 

--- a/scripts/generate_control_api_clients.py
+++ b/scripts/generate_control_api_clients.py
@@ -208,11 +208,19 @@ def response_info(path: str, operation: dict):
     if not content:
         return {"kind": "none", "schema_name": None, "item_schema": None}
 
+    media_type = None
     media_schema = None
     if "application/json" in content:
+        media_type = "application/json"
         media_schema = content["application/json"].get("schema") or {}
     else:
-        media_schema = next(iter(content.values())).get("schema") or {}
+        media_type, media_content = next(iter(content.items()))
+        media_schema = media_content.get("schema") or {}
+
+    if media_schema.get("format") == "binary":
+        return {"kind": "bytes", "schema_name": None, "item_schema": None}
+    if media_type == "text/plain" and media_schema.get("type") == "string":
+        return {"kind": "text", "schema_name": None, "item_schema": None}
 
     schema_name = ref_name(media_schema)
     if schema_name:
@@ -346,6 +354,8 @@ def render_return_hint(response: dict) -> str:
         return "None"
     if kind == "bytes":
         return "bytes"
+    if kind == "text":
+        return "str"
     if kind == "model":
         model_name = schema_model_name(response["schema_name"])
         if model_name:
@@ -380,7 +390,10 @@ def render_method(operation: dict, async_mode: bool) -> list[str]:
     path_expr = operation["path"]
     for original, variable in param_mappings:
         path_expr = path_expr.replace("{" + original + "}", "{" + variable + "}")
-    lines.append(f'        path = f"{path_expr}"')
+    if "{" in path_expr:
+        lines.append(f'        path = f"{path_expr}"')
+    else:
+        lines.append(f'        path = "{path_expr}"')
 
     if operation["query_params"]:
         lines.append("        params = {")

--- a/scripts/generate_control_models.py
+++ b/scripts/generate_control_models.py
@@ -1,4 +1,4 @@
-#!uv run
+#!/usr/bin/env -S uv run
 
 from __future__ import annotations
 

--- a/tests/test_api_control_async.py
+++ b/tests/test_api_control_async.py
@@ -147,6 +147,15 @@ async def test_async_client_handles_bytes_and_none_responses():
 
 
 @pytest.mark.asyncio
+async def test_async_client_handles_text_responses():
+    client, _ = make_client(DummyAsyncResponse(200, content=b"#!/bin/sh\necho install\n"))
+
+    assert await client.devices.installer("9") == "#!/bin/sh\necho install\n"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_async_client_can_lookup_control_methods_by_model_name_or_class():
     client, _ = make_client(DummyAsyncResponse(204))
 

--- a/tests/test_api_control_codegen.py
+++ b/tests/test_api_control_codegen.py
@@ -43,8 +43,11 @@ def test_included_operation_ids_cover_expected_examples():
 
 def test_codegen_emits_return_annotations_for_generated_methods():
     assert DevicesSyncGroup.create.__annotations__["return"] == "control_models.Device"
+    assert DevicesSyncGroup.installer.__annotations__["return"] == "str"
+    assert DevicesSyncGroup.installer_download.__annotations__["return"] == "bytes"
     assert (
         DevicesSyncGroup.list.__annotations__["return"]
         == "control_models.ControlPage[control_models.Device]"
     )
     assert DevicesAsyncGroup.create.__annotations__["return"] == "control_models.Device"
+    assert DevicesAsyncGroup.installer.__annotations__["return"] == "str"

--- a/tests/test_api_control_sync.py
+++ b/tests/test_api_control_sync.py
@@ -142,6 +142,14 @@ def test_sync_client_handles_bytes_and_none_responses():
     none_client.close()
 
 
+def test_sync_client_handles_text_responses():
+    client, _ = make_client(DummyResponse(200, content=b"#!/bin/sh\necho install\n"))
+
+    assert client.devices.installer("9") == "#!/bin/sh\necho install\n"
+
+    client.close()
+
+
 def test_sync_client_can_deserialize_model_lists():
     client, _ = make_client(DummyResponse(204))
 


### PR DESCRIPTION
## Summary
- Regenerated the control API clients and control models from the updated OpenAPI spec.
- Added support for new control endpoints, including application and device organisation access management, installer download, billing block status, and report deletion.
- Updated request/response handling for installer responses returned as text.
- Refreshed generated sync/async wrappers, shared groups, and exported control models.
- Updated the OpenAPI spec and generator scripts to match the new control surface.

## Testing
- `Not run`