### PR TITLE
Fix config ref resolution to look up by element name

### DIFF
--- a/pydoover/ui/declarative.py
+++ b/pydoover/ui/declarative.py
@@ -443,9 +443,23 @@ def _resolve_single_config_ref(value: str, config: Schema) -> Any:
 
     key, type_hint, default = match.groups()
 
+    # Lookup is keyed by the element's `_name` (e.g. "dv_app_position"), which
+    # may differ from the Python attribute on the Schema (e.g. `position`).
+    # Prefer `_element_map` (keyed by `_name`); fall back to attribute access
+    # for elements injected dynamically via `_inject_deployment_config`.
+    element = None
     try:
-        element = getattr(config, key)
-        raw = element.value
+        element = config._element_map.get(key)
+    except AttributeError:
+        pass
+    if element is None:
+        try:
+            element = getattr(config, key)
+        except AttributeError:
+            element = None
+
+    try:
+        raw = element.value if element is not None else None
     except (ValueError, AttributeError):
         raw = None
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3,7 +3,8 @@ import copy
 
 import pytest
 
-from pydoover import ui
+from pydoover import config, ui
+from pydoover.config import ApplicationPosition
 from pydoover.tags import Tag, Tags
 
 from tests.test_tags import (
@@ -190,6 +191,44 @@ class TestCanonicalUiTypes:
         assert data["series"]["temperature"]["displayString"] == "Temperature"
         assert data["series"]["temperature"]["colour"] == "red"
         assert data["series"]["temperature"]["units"] == "C"
+
+
+class TestConfigRefResolution:
+    def _make_schema_cls(self):
+        class S(config.Schema):
+            position = ApplicationPosition(default=120)
+
+        return S
+
+    def test_resolves_position_from_explicit_deployment_value(self):
+        schema = self._make_schema_cls()()
+        schema._inject_deployment_config({"dv_app_position": 120})
+
+        class MyUI(ui.UI):
+            pass
+
+        assert MyUI(schema, None, "app_key").to_schema()["position"] == 120
+
+    def test_resolves_position_from_schema_default_when_omitted(self):
+        schema = self._make_schema_cls()()
+        schema._inject_deployment_config({})
+
+        class MyUI(ui.UI):
+            pass
+
+        assert MyUI(schema, None, "app_key").to_schema()["position"] == 120
+
+    def test_falls_back_to_lookup_default_when_element_absent(self):
+        class S(config.Schema):
+            pass
+
+        schema = S()
+        schema._inject_deployment_config({})
+
+        class MyUI(ui.UI):
+            pass
+
+        assert MyUI(schema, None, "app_key").to_schema()["position"] == 100
 
 
 class TestApplicationUIResolution:


### PR DESCRIPTION
## Summary
- `_resolve_single_config_ref` (in `pydoover/ui/declarative.py`) used `getattr(config, key)`, where `key` is the element's `_name` from the lookup string (e.g. `dv_app_position`). On a `Schema` the element is exposed as the Python attribute name chosen by the user (e.g. `position`), not its `_name`. The `getattr` raised `AttributeError`, the resolver swallowed it, and fell back to the regex's literal default — silently overriding any value the deployment config had set.
- Switched to look up via `_element_map` (keyed by `_name`) first, keeping attribute lookup as a fallback for elements injected dynamically by `_inject_deployment_config`.
- Added regression tests covering: explicit deployment value, schema-default fallback, and missing-element fallback to the lookup default.

## Repro
```python
class S(config.Schema):
    position = ApplicationPosition(default=120)  # _name = "dv_app_position"

class MyUI(ui.UI): pass

s = S(); s._inject_deployment_config({"dv_app_position": 120})
MyUI(s, None, "app_key").to_schema()["position"]
# before: 100  (regex default from "$config.app().dv_app_position:number:100")
# after:  120
```

This is what was producing the symptom on `solar_power_management`: `dv_app_position` deployed as 120 but the running app's UI schema reported 100.

## Test plan
- [x] `pytest tests/test_ui.py` — 17 passed (3 new)
- [x] Broader suite (`pytest tests/ --ignore live/jsonschema-dependent`) — 245 passed
- [ ] Manual sanity check on a device after a pydoover bump in `power-management`

🤖 Generated with [Claude Code](https://claude.com/claude-code)