### PR TITLE
Reuse a persistent gRPC channel for unary requests

### DIFF
--- a/pydoover/__init__.py
+++ b/pydoover/__init__.py
@@ -1,4 +1,4 @@
 __title__ = "pydoover"
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from . import *  # noqa: F403

--- a/pydoover/docker/device_agent/device_agent.py
+++ b/pydoover/docker/device_agent/device_agent.py
@@ -638,6 +638,7 @@ class DeviceAgentInterface(GRPCInterface):
             task.cancel()
         self._stream_tasks.clear()
         logging.info("Closing device agent interface...")
+        await super().close()
 
     @cli_command()
     async def listen_channel(self, channel_name: str) -> None:

--- a/pydoover/docker/grpc_interface.py
+++ b/pydoover/docker/grpc_interface.py
@@ -17,9 +17,36 @@ class GRPCInterface:
 
     This class is designed to be subclassed for specific gRPC services, providing
     a common interface for making asynchronous requests.
+
+    Unary requests share one persistent channel rather than paying a TCP +
+    HTTP/2 handshake per call (~3x per-call latency on loopback, more on
+    constrained devices). If the channel has gone stale — most commonly the
+    server restarting under us — the call fails fast with ``UNAVAILABLE`` and
+    is retried once on a freshly built channel, which is exactly the old
+    channel-per-request behaviour. Every call carries a deadline, so a
+    half-dead connection costs at most one timeout before the channel is
+    rebuilt; a wedged channel can never permanently wedge the client.
     """
 
     stub = NotImplemented
+
+    # Keepalive only pings while calls are in flight
+    # (grpc.keepalive_permit_without_calls stays 0): gRPC servers GOAWAY
+    # clients that ping an idle connection more than once per 5 minutes by
+    # default, so idle-channel health is handled by the retry-on-fresh-channel
+    # path instead of pings.
+    _CHANNEL_OPTIONS = [
+        ("grpc.keepalive_time_ms", 10_000),
+        ("grpc.keepalive_timeout_ms", 5_000),
+        ("grpc.initial_reconnect_backoff_ms", 100),
+        ("grpc.max_reconnect_backoff_ms", 2_000),
+        # Without this, channels share subchannels from a process-global pool,
+        # so a "fresh" channel built after a failure inherits the old broken
+        # subchannel — still in reconnect backoff with a cached refusal — and
+        # the heal-after-restart retry fails too. A local pool makes a rebuilt
+        # channel genuinely reconnect.
+        ("grpc.use_local_subchannel_pool", 1),
+    ]
 
     def __init__(self, app_key: str, uri: str, service_name: str, timeout: int = 7):
         self.app_key = app_key
@@ -27,12 +54,54 @@ class GRPCInterface:
         self.timeout = timeout
         self.service_name = service_name
 
+        self._channel: grpc.aio.Channel | None = None
+        self._channel_stub = None
+        self._channel_lock = asyncio.Lock()
+
+    async def _get_stub(self):
+        async with self._channel_lock:
+            if self._channel is None:
+                self._channel = grpc.aio.insecure_channel(
+                    self.uri, options=self._CHANNEL_OPTIONS
+                )
+                self._channel_stub = self.stub(self._channel)
+            return self._channel_stub
+
+    async def _discard_channel(self):
+        """Drop the shared channel so the next call builds a fresh one.
+
+        The old channel is closed in the background with a grace period so
+        any concurrent in-flight calls on it can finish rather than being
+        cancelled out from under their callers.
+        """
+        async with self._channel_lock:
+            channel, self._channel, self._channel_stub = self._channel, None, None
+        if channel is not None:
+            close_task = asyncio.ensure_future(channel.close(grace=self.timeout))
+            close_task.add_done_callback(lambda t: t.exception())
+
     async def make_request(self, stub_call, request, *args, **kwargs):
         try:
-            async with grpc.aio.insecure_channel(self.uri) as channel:
-                stub = self.stub(channel)
+            try:
+                stub = await self._get_stub()
                 response = await getattr(stub, stub_call)(request, timeout=self.timeout)
-                return self.process_response(stub_call, response, *args, **kwargs)
+            except grpc.aio.AioRpcError as e:
+                # The channel itself is suspect (server restarted under us, or
+                # the connection went half-dead and the deadline fired) — not
+                # an application error. Rebuild; retry only the fail-fast case
+                # so a genuinely slow server doesn't double its worst-case
+                # latency.
+                if e.code() not in (
+                    grpc.StatusCode.UNAVAILABLE,
+                    grpc.StatusCode.DEADLINE_EXCEEDED,
+                ):
+                    raise
+                await self._discard_channel()
+                if e.code() is not grpc.StatusCode.UNAVAILABLE:
+                    raise
+                stub = await self._get_stub()
+                response = await getattr(stub, stub_call)(request, timeout=self.timeout)
+            return self.process_response(stub_call, response, *args, **kwargs)
         except (DooverAPIError, HTTPError):
             raise
         except Exception as e:
@@ -40,6 +109,9 @@ class GRPCInterface:
             raise DooverAPIError(
                 f"gRPC request failed ({self.__class__.__name__}.{stub_call}): {e}"
             ) from e
+
+    async def close(self):
+        await self._discard_channel()
 
     def process_response(self, stub_call: str, response, *args, **kwargs):
         if response is None:

--- a/pydoover/docker/modbus/modbus_iface.py
+++ b/pydoover/docker/modbus/modbus_iface.py
@@ -153,6 +153,7 @@ class ModbusInterface(GRPCInterface):
         log.info("Closing modbus interface")
         for task in self.subscription_tasks:
             task.cancel()
+        await super().close()
 
     @staticmethod
     def _get_bus_request(

--- a/pydoover/docker/platform/platform.py
+++ b/pydoover/docker/platform/platform.py
@@ -252,6 +252,7 @@ class PlatformInterface(GRPCInterface):
         log.info("Closing platform interface...")
         for listener in self.pulse_counter_listeners:
             listener.cancel()
+        await super().close()
 
     def process_response(self, stub_call: str, response, **kwargs):
         response = super().process_response(stub_call, response, **kwargs)

--- a/tests/test_grpc_interface_channel.py
+++ b/tests/test_grpc_interface_channel.py
@@ -1,0 +1,101 @@
+"""Tests for persistent-channel reuse in GRPCInterface.
+
+Unary requests share one channel; a stale channel (server restarted under
+us) must fail fast and heal via a single retry on a fresh channel, never
+wedging the client.
+"""
+
+import asyncio
+
+import grpc
+import pytest
+
+from pydoover.docker.device_agent import DeviceAgentInterface
+from pydoover.models.data.exceptions import DooverAPIError
+from pydoover.models.generated.device_agent import (
+    device_agent_pb2,
+    device_agent_pb2_grpc,
+)
+
+
+class EchoServicer(device_agent_pb2_grpc.deviceAgentServicer):
+    async def TestComms(self, request, context):
+        return device_agent_pb2.TestCommsResponse(
+            response_header=device_agent_pb2.ResponseHeader(
+                success=True, cloud_synced=True, cloud_ready=True, response_code=200
+            ),
+            response=request.message,
+        )
+
+
+async def start_server(port: int = 0) -> tuple[grpc.aio.Server, int]:
+    server = grpc.aio.server()
+    device_agent_pb2_grpc.add_deviceAgentServicer_to_server(EchoServicer(), server)
+    port = server.add_insecure_port(f"127.0.0.1:{port}")
+    await server.start()
+    return server, port
+
+
+@pytest.mark.asyncio
+async def test_channel_is_reused_across_requests():
+    server, port = await start_server()
+    client = DeviceAgentInterface(
+        app_key="t", dda_uri=f"127.0.0.1:{port}", dda_timeout=2
+    )
+    try:
+        req = device_agent_pb2.TestCommsRequest(message="one")
+        await client.make_request("TestComms", req)
+        first_channel = client._channel
+        assert first_channel is not None
+
+        await client.make_request("TestComms", req)
+        assert client._channel is first_channel
+    finally:
+        await client.close()
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_survives_server_restart():
+    server, port = await start_server()
+    client = DeviceAgentInterface(
+        app_key="t", dda_uri=f"127.0.0.1:{port}", dda_timeout=2
+    )
+    req = device_agent_pb2.TestCommsRequest(message="hi")
+    try:
+        resp = await client.make_request("TestComms", req)
+        assert resp.response == "hi"
+
+        # Kill the server: the call must fail fast (well under the deadline
+        # budget of two attempts), not hang.
+        await server.stop(None)
+        await server.wait_for_termination()
+        with pytest.raises(DooverAPIError):
+            await asyncio.wait_for(client.make_request("TestComms", req), timeout=5)
+
+        # Server comes back on the same port: the client must heal without
+        # being recreated.
+        server, bound = await start_server(port)
+        assert bound == port, "test harness failed to re-bind the port"
+        resp = await client.make_request("TestComms", req)
+        assert resp.response == "hi"
+    finally:
+        await client.close()
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_close_discards_channel():
+    server, port = await start_server()
+    client = DeviceAgentInterface(
+        app_key="t", dda_uri=f"127.0.0.1:{port}", dda_timeout=2
+    )
+    try:
+        await client.make_request(
+            "TestComms", device_agent_pb2.TestCommsRequest(message="x")
+        )
+        assert client._channel is not None
+        await client.close()
+        assert client._channel is None
+    finally:
+        await server.stop(None)


### PR DESCRIPTION
## Summary

`GRPCInterface.make_request` opened a brand-new channel per unary call, paying a TCP + HTTP/2 handshake every time: **~930 µs/call vs ~270 µs/call** with a reused channel on loopback (Mac; the gap is milliseconds on a CM4). This affects every `DeviceAgentInterface` / `PlatformInterface` / `ModbusInterface` request an app makes.

The per-request channel was deliberate — long-lived channels previously caused stability issues — so the design constraint here is: **the failure path must degrade to exactly the old behaviour, never worse.**

## How stability is preserved

- **Agent restarts under the app** → first call on the stale channel fails fast with `UNAVAILABLE`, gets retried once on a freshly built channel (= the old per-request behaviour). Verified by `test_survives_server_restart`, which kills and rebinds a real grpc.aio server mid-client-lifetime.
- **Half-dead connection** → every call still carries `timeout=self.timeout`, so the worst case is one deadline, after which the channel is discarded and the *next* call rebuilds. `DEADLINE_EXCEEDED` is deliberately *not* retried so a genuinely slow agent doesn't double its worst-case latency.
- **Subchannel-pool trap** → `grpc.use_local_subchannel_pool=1`. Without it, a "fresh" channel inherits the old broken subchannel from the process-global pool (still in reconnect backoff with a cached refusal) and the heal-after-restart retry fails once more than necessary. Found this via the restart test failing.
- **Keepalive trap** → keepalive only pings while calls are in flight (`keepalive_permit_without_calls` left at 0). Idle pings trigger server `GOAWAY (too_many_pings)`, which manifests as connection flapping — possibly a contributor to the original instability if reuse was tried before.
- **No background machinery** — no health-check task, no pooling, no retry of application errors. The only new behaviour is "if the channel looks dead, do what we used to do every time."

Concurrent in-flight calls on a discarded channel aren't cancelled — the old channel closes in the background with `grace=timeout`.

Streaming (`stream_channel_events`) is untouched; it already owns a long-lived channel with its own reconnect loop.

## Changes

- `grpc_interface.py`: persistent channel + lazy build, discard-and-retry-once on `UNAVAILABLE`, discard-only on `DEADLINE_EXCEEDED`, `close()` releases the channel
- `device_agent.py` / `platform.py` / `modbus_iface.py`: `close()` now chains to `super().close()`
- version → 1.5.1
- New `tests/test_grpc_interface_channel.py`: reuse, kill/restart-heal (against a real grpc.aio server), and close semantics

## Test plan

- [x] 381 passed (full suite minus live-API tests), new restart test stable across repeated runs
- [x] Benchmarked through the real `make_request`: 274 µs/call vs ~930 µs/call before (3.4×)
- [ ] Soak on a real device alongside a restarting DDA before release

Based on `feat/zstd-orjson` (the 1.5.0 release branch) — retarget if that merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)