### PR TITLE
feat: add timestamp precision options

### DIFF
--- a/pydoover/ui/variable.py
+++ b/pydoover/ui/variable.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from typing import Any
+from typing import Any, Literal
 
 from .declarative import _value_is_live, is_tag_reference, normalize_ui_value
 from .element import Element
@@ -247,15 +247,34 @@ class DateTimeVariable(Variable):
 class Timestamp(Variable):
     type = "uiTimestamp"
 
-    def __init__(self, display_name: str, value: datetime, **kwargs):
-        # this might do some weird stuff where people think they can have ranges and what not, but yeah...
-        # this will do for now...
+    def __init__(
+        self,
+        display_name: str,
+        value: datetime | int | float | Any = NotSet,
+        precision: Literal["second", "minute"] | Any = NotSet,
+        absolute_format: str | Any = NotSet,
+        **kwargs,
+    ):
+        # ``precision`` controls how often the frontend refreshes the relative
+        # label. Second precision supports countdown-style timestamps backed by
+        # one fixed ms-since-epoch value instead of per-second app updates.
         super().__init__(display_name, value=value, var_type="timestamp", **kwargs)
+        self.precision = precision
+        self.absolute_format = absolute_format
 
     def to_dict(self):
         result = super().to_dict()
         if is_tag_reference(self.value):
             result["currentValue"] = self.value
-        else:
-            result["currentValue"] = self.value and int(self.value.timestamp() * 1000)
+        elif isinstance(self.value, datetime):
+            result["currentValue"] = int(self.value.timestamp() * 1000)
+        elif self.value is not NotSet:
+            result["currentValue"] = self.value
+
+        if self.precision is not NotSet:
+            result["precision"] = self.precision
+
+        if self.absolute_format is not NotSet:
+            result["absoluteFormat"] = self.absolute_format
+
         return normalize_ui_value(result)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -192,6 +192,33 @@ class TestCanonicalUiTypes:
         assert data["series"]["temperature"]["colour"] == "red"
         assert data["series"]["temperature"]["units"] == "C"
 
+    def test_timestamp_serializes_ms_epoch_precision_and_absolute_format(self):
+        timestamp = ui.Timestamp(
+            "Turns off at",
+            name="turns_off_at",
+            value=1_777_511_327_616,
+            precision="second",
+            absolute_format="HH:mm:ss",
+        )
+
+        data = timestamp.to_dict()
+
+        assert data["type"] == "uiTimestamp"
+        assert data["currentValue"] == 1_777_511_327_616
+        assert data["precision"] == "second"
+        assert data["absoluteFormat"] == "HH:mm:ss"
+
+    def test_timestamp_still_serializes_datetime_values_as_ms_since_epoch(self):
+        from datetime import datetime, timezone
+
+        timestamp = ui.Timestamp(
+            "Started",
+            name="started",
+            value=datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc),
+        )
+
+        assert timestamp.to_dict()["currentValue"] == 1_782_302_400_000
+
 
 class TestLiveTagPropagation:
     """The customer-site gates Live Mode on a UI element's ``live`` field;


### PR DESCRIPTION
## Summary
- Extends `ui.Timestamp` with `precision` (`"second"` or `"minute"`) and `absolute_format` options so apps can ask the frontend for finer-grained relative timestamp rendering.
- Allows numeric timestamp values to pass through as ms-since-epoch `currentValue`, matching the existing frontend `uiTimestamp` contract and the `turnsOffAt` use case.
- Preserves existing datetime serialization to ms-since-epoch.

Companion frontend PR: spaneng/customer-site consumes `precision: "second"` to tick countdown labels once per second without the app publishing per-second UI updates.

## Test Plan
- `uvx ruff check pydoover/ui/variable.py tests/test_ui.py` ✅
- `uvx ruff format --check pydoover/ui/variable.py tests/test_ui.py` ✅
- `uv run pytest tests/test_ui.py -q` ✅ (passes with existing pytest mark/config warnings)
