### PR TITLE
feat(ui): direct commands, command timeouts, and datetime input options

### DIFF
--- a/pydoover/__init__.py
+++ b/pydoover/__init__.py
@@ -1,4 +1,4 @@
 __title__ = "pydoover"
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 from . import *  # noqa: F403

--- a/pydoover/ui/interaction.py
+++ b/pydoover/ui/interaction.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from .declarative import normalize_ui_value
 from .element import Element
-from .misc import ConfirmDialog, Option, NotSet
+from .misc import ConfirmDialog, Option, NotSet, duration_ms
 
 if TYPE_CHECKING:
     from .manager import UICommandsManager
@@ -42,6 +42,15 @@ class Interaction(Element):
         A function to transform and check the new value before setting it. Defaults to None.
     show_activity: bool, optional
         Whether to show this interaction in the activity log. Defaults to None which uses the site default.
+    command_timeout: timedelta | float, optional
+        How long the site waits for the device to acknowledge a command from this
+        interaction before marking it as failed. A timedelta, or seconds.
+        Defaults to waiting forever.
+    direct: bool, optional
+        If True, commands from this interaction are written straight into the
+        ui_cmds aggregate by the site (what a device would do on accept) instead
+        of going through the RPC transaction flow. No acknowledgement is
+        expected. Defaults to False.
     """
 
     type = "uiInteraction"
@@ -54,6 +63,8 @@ class Interaction(Element):
         show_activity: bool = NotSet,
         requires_confirm: bool | ConfirmDialog = NotSet,
         global_interaction: bool = NotSet,
+        command_timeout=NotSet,
+        direct: bool = NotSet,
         **kwargs,
     ):
         super().__init__(display_name, **kwargs)
@@ -73,6 +84,8 @@ class Interaction(Element):
         self.requires_confirm = requires_confirm
 
         self.global_interaction = global_interaction
+        self.command_timeout = command_timeout
+        self.direct = direct
 
     @property
     def value(self):
@@ -102,6 +115,10 @@ class Interaction(Element):
                 res["requiresConfirm"] = self.requires_confirm
         if self.global_interaction is not NotSet:
             res["global"] = self.global_interaction
+        if self.command_timeout is not NotSet:
+            res["commandTimeout"] = duration_ms(self.command_timeout)
+        if self.direct is not NotSet:
+            res["direct"] = self.direct
         if self.show_activity is not NotSet:
             res["showActivity"] = self.show_activity
         if self.default is not NotSet:

--- a/pydoover/ui/misc.py
+++ b/pydoover/ui/misc.py
@@ -1,7 +1,16 @@
+from datetime import timedelta
 from typing import Any, ClassVar
 
 from .declarative import _value_is_live, normalize_ui_value
 from ..utils.utils import sanitize_display_name
+
+
+def duration_ms(value: "timedelta | int | float") -> int:
+    """Convert a duration (timedelta, or seconds) to the platform wire format
+    of integer milliseconds."""
+    if isinstance(value, timedelta):
+        return int(value.total_seconds() * 1000)
+    return int(value * 1000)
 
 
 class NotSet:

--- a/pydoover/ui/parameter.py
+++ b/pydoover/ui/parameter.py
@@ -2,7 +2,7 @@ import warnings
 
 from .declarative import normalize_ui_value
 from .interaction import Interaction
-from .misc import NotSet
+from .misc import NotSet, duration_ms
 
 
 def _warn_legacy_ui_alias(old_name: str, new_name: str) -> None:
@@ -111,7 +111,7 @@ class BooleanParameter(Parameter):
 class DatetimeInput(Parameter):
     """A datetime input that can be used to request date and time values from a user.
 
-    Internally, all datetime values are stored as epoch seconds in UTC
+    Values are integer epoch milliseconds in UTC.
 
     Attributes
     ----------
@@ -119,15 +119,40 @@ class DatetimeInput(Parameter):
         The name of the parameter.
     display_name: str
         The display name of the parameter.
-    include_time: bool
-        Whether to include time in the datetime picker. Defaults to False.
+    pickers: list[str], optional
+        Which pickers the input offers: "date" and/or "time".
+        Defaults to both.
+    direction: str, optional
+        Constrain values relative to now: "past" or "future". Also restricts
+        the selectable calendar dates.
+    max_past: timedelta | float, optional
+        How far in the past values may be. A timedelta, or seconds.
+    max_future: timedelta | float, optional
+        How far in the future values may be. A timedelta, or seconds.
     """
 
     type = "uiDatetimeInput"
 
-    def __init__(self, display_name: str, include_time: bool = False, **kwargs):
+    def __init__(
+        self,
+        display_name: str,
+        include_time: bool = NotSet,
+        *,
+        pickers: list[str] = NotSet,
+        direction: str = NotSet,
+        max_past=NotSet,
+        max_future=NotSet,
+        **kwargs,
+    ):
         super().__init__(display_name, **kwargs)
-        self.include_time = include_time
+        if include_time is not NotSet:
+            _warn_legacy_ui_alias("include_time", "pickers")
+            if pickers is NotSet:
+                pickers = ["date", "time"] if include_time else ["date"]
+        self.pickers = pickers
+        self.direction = direction
+        self.max_past = max_past
+        self.max_future = max_future
 
     # @property
     # def current_value(self) -> datetime | None:
@@ -144,14 +169,18 @@ class DatetimeInput(Parameter):
 
     def to_dict(self):
         result = super().to_dict()
-        result["includeTime"] = self.include_time
+        if self.pickers is not NotSet:
+            result["pickers"] = self.pickers
+        if self.direction is not NotSet:
+            result["direction"] = self.direction
+        if self.max_past is not NotSet:
+            result["maxPast"] = duration_ms(self.max_past)
+        if self.max_future is not NotSet:
+            result["maxFuture"] = duration_ms(self.max_future)
         return normalize_ui_value(result)
 
 
 class TimeInput(DatetimeInput):
-    """A time-only input."""
+    """A time-of-day input. Values are seconds into the local day."""
 
     type = "uiTimeInput"
-
-    def __init__(self, display_name: str, **kwargs):
-        super().__init__(display_name, include_time=True, **kwargs)

--- a/pydoover/ui/submodule.py
+++ b/pydoover/ui/submodule.py
@@ -238,4 +238,29 @@ class RemoteComponent(Container):
 
 
 class TabContainer(Container):
+    """A container that renders its children as tabs.
+
+    Parameters
+    ----------
+    default_page: int, optional
+        0-based index of the tab open by default, in position-sorted order of
+        the visible children. Defaults to the first tab.
+    """
+
     type = "uiTabs"
+
+    def __init__(
+        self,
+        display_name: str,
+        children: list[Element] = None,
+        default_page: int = NotSet,
+        **kwargs,
+    ):
+        super().__init__(display_name, children, **kwargs)
+        self.default_page = default_page
+
+    def to_dict(self):
+        result = super().to_dict()
+        if self.default_page is not NotSet:
+            result["defaultPage"] = self.default_page
+        return normalize_ui_value(result)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+from datetime import timedelta
 
 import pytest
 
@@ -390,3 +391,71 @@ class TestApplicationUIResolution:
             )
 
         asyncio.run(run_test())
+
+
+class TestUiCommandOptions:
+    def test_command_timeout_and_direct_serialize(self):
+        button = ui.Button(
+            "Restart",
+            name="restart",
+            command_timeout=timedelta(seconds=5),
+            direct=True,
+        )
+
+        data = button.to_dict()
+
+        assert data["commandTimeout"] == 5000
+        assert data["direct"] is True
+
+    def test_command_timeout_accepts_seconds(self):
+        button = ui.Button("Restart", name="restart", command_timeout=2.5)
+
+        assert button.to_dict()["commandTimeout"] == 2500
+
+    def test_options_omitted_by_default(self):
+        data = ui.Button("Restart", name="restart").to_dict()
+
+        assert "commandTimeout" not in data
+        assert "direct" not in data
+
+
+class TestDatetimeInputOptions:
+    def test_datetime_options_serialize(self):
+        dt = ui.DatetimeInput(
+            "Start",
+            name="start",
+            pickers=["date"],
+            direction="future",
+            max_future=timedelta(days=7),
+            max_past=3600,
+        )
+
+        data = dt.to_dict()
+
+        assert data["pickers"] == ["date"]
+        assert data["direction"] == "future"
+        assert data["maxFuture"] == 7 * 24 * 60 * 60 * 1000
+        assert data["maxPast"] == 3600 * 1000
+        assert "includeTime" not in data
+
+    def test_include_time_is_deprecated_alias(self):
+        with pytest.warns(DeprecationWarning):
+            dt = ui.DatetimeInput("Start", name="start", include_time=True)
+
+        assert dt.to_dict()["pickers"] == ["date", "time"]
+
+    def test_time_input_no_deprecation(self):
+        data = ui.TimeInput("Start Time", name="start_time").to_dict()
+
+        assert data["type"] == "uiTimeInput"
+        assert "pickers" not in data
+
+
+class TestTabContainerOptions:
+    def test_default_page_serializes(self):
+        tabs = ui.TabContainer("Tabs", name="tabs", default_page=1)
+
+        assert tabs.to_dict()["defaultPage"] == 1
+
+    def test_default_page_omitted_by_default(self):
+        assert "defaultPage" not in ui.TabContainer("Tabs", name="tabs").to_dict()


### PR DESCRIPTION
Device-side support for the new interpreterV2 command/datetime contract (customer-site `feat/interpreter-various`).

## New options

**All interactions** (buttons, params, sliders, switches, …):
- `command_timeout` — how long the site waits for the device to acknowledge a command (RPC status or reported state) before marking it failed and reverting the optimistic value. Takes a `timedelta` or seconds; serialized as `commandTimeout` in **ms** per the platform convention. Omit to keep today's wait-forever behaviour.
- `direct` — opt-in flag telling the site to write the value straight into the `ui_cmds` aggregate (what the device would do on accept) instead of the RPC transaction flow. No spinner, no ack. Pair with a `$cmds.<name>` current-value lookup for instant reflection.

**`DatetimeInput`** — values are integer **epoch ms** in UTC (the site picker was switched from seconds; the old `includeTime` field was never read by the site):
- `pickers=["date", "time"]` — which pickers the input offers (calendar and/or hour/minute/am-pm dropdowns).
- `direction="past" | "future"` — constrains values relative to now and greys out out-of-range calendar days.
- `max_past` / `max_future` — window limits (`timedelta` or seconds → ms on the wire), e.g. `max_future=timedelta(days=7)` → *"must be within 7 days from now"* in the UI.
- `include_time` is deprecated and maps onto `pickers`.

**`TabContainer`**:
- `default_page` — 0-based index of the tab open by default (position-sorted visible children).

## Notes
- `Button.disabled` already existed and now actually works on the site (it was in the site schema but never wired into the component).
- All new fields are omitted from `to_dict()` when unset, so existing payloads are unchanged.
- `tests/test_ui.py`: 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)