### PR TITLE
Fix: accept return_aggregate on REST update_channel_aggregate (processors crash writing tags)

### DIFF
--- a/pydoover/api/data/_async.py
+++ b/pydoover/api/data/_async.py
@@ -546,8 +546,15 @@ class AsyncDataClient(BaseClient):
         clear_attachments: bool = False,
         log_update: bool = False,
         replace_keys: list[str] | None = None,
+        return_aggregate: bool = True,
         organisation_id: int | None = None,
     ) -> Aggregate | None:
+        # ``return_aggregate`` mirrors the device-agent client's kwarg so the
+        # shared TagsManager can call this over either transport. When False,
+        # skip returning the updated aggregate — over REST that is exactly the
+        # ``suppress_response`` path (the server does not echo the aggregate).
+        if not return_aggregate:
+            suppress_response = True
         method = "PUT" if replace_data else "PATCH"
         result = await self._request(
             method,

--- a/pydoover/api/data/_sync.py
+++ b/pydoover/api/data/_sync.py
@@ -515,8 +515,15 @@ class DataClient(BaseClient):
         clear_attachments: bool = False,
         log_update: bool = False,
         replace_keys: list[str] | None = None,
+        return_aggregate: bool = True,
         organisation_id: int | None = None,
     ) -> Aggregate | None:
+        # ``return_aggregate`` mirrors the device-agent client's kwarg so the
+        # shared TagsManager can call this over either transport. When False,
+        # skip returning the updated aggregate — over REST that is exactly the
+        # ``suppress_response`` path (the server does not echo the aggregate).
+        if not return_aggregate:
+            suppress_response = True
         method = "PUT" if replace_data else "PATCH"
         result = self._request(
             method,

--- a/pydoover/processor/data_client.py
+++ b/pydoover/processor/data_client.py
@@ -247,6 +247,7 @@ class ProcessorDataClient(AsyncDataClient):
         clear_attachments: bool = False,
         log_update: bool = False,
         replace_keys: list[str] | None = None,
+        return_aggregate: bool = True,
         allow_invoking_channel: bool = False,
         agent_id: int | None = None,
         organisation_id: int | None = None,
@@ -264,6 +265,7 @@ class ProcessorDataClient(AsyncDataClient):
             clear_attachments=clear_attachments,
             log_update=log_update,
             replace_keys=replace_keys,
+            return_aggregate=return_aggregate,
             organisation_id=organisation_id,
         )
 

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -112,3 +112,32 @@ async def test_processor_client_fetches_message_logs_with_agent_fallback():
         )
     ]
     assert logs[1].type == "user.log"
+
+
+@pytest.mark.asyncio
+async def test_update_aggregate_return_aggregate_maps_to_suppress_response():
+    # Regression: the shared TagsManager commits tags via
+    # update_channel_aggregate(..., return_aggregate=False). Before the fix the
+    # REST clients (AsyncDataClient / ProcessorDataClient) rejected that kwarg
+    # with TypeError, crashing every processor that writes a tag. It must be
+    # accepted and map to the suppress_response (no-echo) path.
+    client = ProcessorDataClient("https://data.example")
+    client.agent_id = 123
+    params_seen = []
+
+    async def fake_request(method, path, **kwargs):
+        params_seen.append(kwargs.get("params"))
+        return {}
+
+    client._request = fake_request
+
+    result = await client.update_channel_aggregate(
+        "tag_values", {"app": {"tag": 1}}, return_aggregate=False
+    )
+    assert result is None
+    assert params_seen[-1]["suppress_response"] is True
+
+    # Default return_aggregate=True leaves the response un-suppressed.
+    await client.update_channel_aggregate("tag_values", {"app": {"tag": 2}})
+    await client.close()
+    assert params_seen[-1]["suppress_response"] is None


### PR DESCRIPTION
## Problem

Any **cloud processor** (`pydoover.processor.Application`) that writes a tag via `set_tag`/`commit_tags` crashes on commit with:

```
TypeError: ProcessorDataClient.update_channel_aggregate() got an unexpected keyword argument 'return_aggregate'
```

The shared `TagsManager` commits tags by calling `update_channel_aggregate(..., return_aggregate=False)` (`pydoover/tags/manager.py:485, 524, 768`). That kwarg exists on the **device-agent gRPC client** (`docker/device_agent/device_agent.py`), but **not** on the REST clients — `AsyncDataClient` / `SyncDataClient` (`api/data/_async.py`, `_sync.py`) and the `ProcessorDataClient` override (`processor/data_client.py`).

So device apps are fine (they use the device-agent client), but **processors break the moment they touch the tag system** — the failure surfaces at the end of the invocation, so setup/handlers appear to run and then silently produce nothing.

This was hit in a real processor app: the very first `set_tag` (seeding state) took the whole invocation down.

## Fix

Add `return_aggregate: bool = True` to the base `AsyncDataClient`/`SyncDataClient` `update_channel_aggregate` and forward it through the `ProcessorDataClient` override. Over REST it maps onto the existing `suppress_response` no-echo path:

```python
if not return_aggregate:
    suppress_response = True
```

`return_aggregate=False` → `suppress_response=True` → returns `None`, matching the device-agent client's semantics that `TagsManager` already relies on.

Purely additive — the default (`True`) preserves existing behaviour for every current caller.

## Test

Adds a regression test (`tests/test_api_data.py`) asserting `ProcessorDataClient.update_channel_aggregate(..., return_aggregate=False)` no longer raises and maps to `suppress_response=True` (and that the default leaves the response un-suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)