### PR TITLE
Fix device agent attachment downloads in CLI

### DIFF
--- a/pydoover/__init__.py
+++ b/pydoover/__init__.py
@@ -1,4 +1,4 @@
 __title__ = "pydoover"
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 
 from . import *  # noqa: F403

--- a/pydoover/cli/sub_section.py
+++ b/pydoover/cli/sub_section.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import datetime
 import inspect
 import json
+import sys
 import typing
 from typing import Any, Protocol, cast
 
@@ -91,7 +92,8 @@ class SubSection:
                         result = asyncio.run(result)
                 except Exception as e:
                     print(
-                        f"An error occurred while running {func_to_run.__name__}: {e}"
+                        f"An error occurred while running {func_to_run.__name__}: {e}",
+                        file=sys.stderr,
                     )
                     return
 

--- a/pydoover/docker/device_agent/device_agent.py
+++ b/pydoover/docker/device_agent/device_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64 as base64_module
 import copy
 import logging
 import re
@@ -7,6 +8,7 @@ import json
 
 from collections.abc import Callable
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from ...utils.snowflake import generate_snowflake_id_at
@@ -645,13 +647,102 @@ class DeviceAgentInterface(GRPCInterface):
             return None
         return Aggregate.from_proto(resp.aggregate)
 
-    @cli_command()
     async def fetch_message_attachment(self, attachment: Attachment) -> File:
         req = device_agent_pb2.FetchAttachmentRequest(
             attachment=attachment.to_proto(),
         )
         resp = await self.make_request("FetchAttachment", req)
         return File.from_proto(resp.file)
+
+    @cli_command(name="fetch_message_attachment")
+    async def _cli_fetch_message_attachment(
+        self,
+        url: str,
+        output: str | None = None,
+        force: bool = False,
+        base64: bool = False,
+    ) -> dict[str, Any] | None:
+        """Download an attachment from its URL.
+
+        When no output path is supplied, ASCII attachments are written as text.
+        Attachments containing non-ASCII bytes are written as raw bytes when
+        stdout is redirected or piped. Binary output to an interactive terminal
+        is refused unless base64 output is requested. Status and error messages
+        are not written to stdout in these modes.
+
+        Parameters
+        ----------
+        url : str
+            Attachment URL returned by a message or aggregate.
+        output : str, optional
+            File path at which to save the downloaded attachment.
+        force : bool, optional
+            Overwrite the output file if it already exists.
+        base64 : bool, optional
+            Write the attachment to stdout as Base64-encoded ASCII text.
+        """
+        if output is not None and base64:
+            raise ValueError("--output and --base64 cannot be used together")
+
+        output_path = Path(output) if output is not None else None
+        if output_path is not None and output_path.exists() and not force:
+            raise FileExistsError(
+                f"{output_path} already exists; use --force to overwrite it"
+            )
+
+        # FetchAttachment currently only uses the URL. Populate the remaining
+        # protobuf fields with harmless placeholders so callers do not need to
+        # reproduce metadata they already received alongside the URL.
+        attachment = Attachment(
+            filename="attachment",
+            content_type="application/octet-stream",
+            size=0,
+            url=url,
+        )
+
+        try:
+            downloaded = await self.fetch_message_attachment(attachment)
+        finally:
+            await self.close()
+
+        if base64:
+            encoded = base64_module.b64encode(downloaded.data).decode("ascii")
+            sys.stdout.write(encoded + "\n")
+            sys.stdout.flush()
+            return None
+
+        if output is None:
+            try:
+                text = downloaded.data.decode("ascii")
+            except UnicodeDecodeError:
+                pass
+            else:
+                sys.stdout.write(text)
+                sys.stdout.flush()
+                return None
+
+            if sys.stdout.isatty():
+                raise RuntimeError(
+                    "Binary attachment cannot be written to an interactive terminal; "
+                    "use --output PATH, --base64, or redirect stdout"
+                )
+
+            binary_stdout = getattr(sys.stdout, "buffer", None)
+            if binary_stdout is None:
+                raise RuntimeError(
+                    "Binary stdout is unavailable; specify an output path with --output"
+                )
+            binary_stdout.write(downloaded.data)
+            binary_stdout.flush()
+            return None
+
+        assert output_path is not None
+        output_path.write_bytes(downloaded.data)
+        return {
+            "path": str(output_path),
+            "content_type": downloaded.content_type,
+            "size": len(downloaded.data),
+        }
 
     async def close(self):
         for task in self._stream_tasks.values():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,10 @@ class FakeInterface:
     def set_flags(self, replace_data: bool = False, only_if_changed: bool = True):
         return {"replace_data": replace_data, "only_if_changed": only_if_changed}
 
+    @command()
+    def fail(self):
+        raise RuntimeError("boom")
+
 
 class FakeModel:
     def __init__(self, value):
@@ -107,6 +111,14 @@ def test_cli_bool_flag_default_true_is_store_false(capsys):
 
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {"replace_data": False, "only_if_changed": False}
+
+
+def test_cli_command_errors_are_written_to_stderr(capsys):
+    _run_fake_cli(["fake", "fail"])
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "An error occurred while running fail: boom\n"
 
 
 def test_cli_exception_handler_does_not_require_debug_attr(monkeypatch, capsys):

--- a/tests/test_device_agent.py
+++ b/tests/test_device_agent.py
@@ -7,6 +7,7 @@ These tests mock the gRPC layer (make_request / process_response) to verify that
 """
 
 import asyncio
+from io import BytesIO, StringIO
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,7 +15,7 @@ import pytest
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Struct
 
-from pydoover.models.data import Aggregate
+from pydoover.models.data import Aggregate, Attachment, File
 from pydoover.models.generated.device_agent import device_agent_pb2
 from pydoover.models.data.exceptions import DooverAPIError, HTTPError, NotFoundError
 from pydoover.docker.device_agent import DeviceAgentInterface, MockDeviceAgentInterface
@@ -229,6 +230,160 @@ class TestUpdateAggregate:
 
         with pytest.raises(NotFoundError):
             await self.dda.update_channel_aggregate("nonexistent", {"data": 1})
+
+
+# ── fetch_message_attachment CLI adapter ─────────────────────────────────────────────
+
+
+class _BinaryStdout:
+    def __init__(self, isatty=False):
+        self.buffer = BytesIO()
+        self.text = StringIO()
+        self._isatty = isatty
+
+    def write(self, value):
+        return self.text.write(value)
+
+    def flush(self):
+        return None
+
+    def isatty(self):
+        return self._isatty
+
+
+class TestFetchMessageAttachmentCLI:
+    def setup_method(self):
+        self.dda = DeviceAgentInterface(app_key="test", dda_uri="localhost:50051")
+        self.dda.fetch_message_attachment = AsyncMock(
+            return_value=File(
+                filename="ignored.bin",
+                content_type="application/octet-stream",
+                size=4,
+                data=b"\x00\x01\xff\n",
+            )
+        )
+        self.dda.close = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_only_url_is_used_and_non_ascii_bytes_are_written_to_binary_stdout(
+        self, monkeypatch
+    ):
+        stdout = _BinaryStdout()
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        result = await self.dda._cli_fetch_message_attachment(
+            "https://example.com/attachments/123"
+        )
+
+        assert result is None
+        assert stdout.text.getvalue() == ""
+        assert stdout.buffer.getvalue() == b"\x00\x01\xff\n"
+        attachment = self.dda.fetch_message_attachment.await_args.args[0]
+        assert isinstance(attachment, Attachment)
+        assert attachment.url == "https://example.com/attachments/123"
+        assert attachment.filename == "attachment"
+        assert attachment.content_type == "application/octet-stream"
+        assert attachment.size == 0
+        self.dda.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ascii_content_is_written_as_text(self, monkeypatch):
+        self.dda.fetch_message_attachment.return_value = File(
+            filename="example.txt",
+            content_type="text/plain",
+            size=12,
+            data=b"hello world\n",
+        )
+        stdout = _BinaryStdout()
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        result = await self.dda._cli_fetch_message_attachment(
+            "https://example.com/attachments/123"
+        )
+
+        assert result is None
+        assert stdout.text.getvalue() == "hello world\n"
+        assert stdout.buffer.getvalue() == b""
+
+    @pytest.mark.asyncio
+    async def test_binary_content_is_refused_on_interactive_terminal(self, monkeypatch):
+        stdout = _BinaryStdout(isatty=True)
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        with pytest.raises(RuntimeError, match="--output PATH, --base64"):
+            await self.dda._cli_fetch_message_attachment(
+                "https://example.com/attachments/123"
+            )
+
+        assert stdout.text.getvalue() == ""
+        assert stdout.buffer.getvalue() == b""
+
+    @pytest.mark.asyncio
+    async def test_base64_outputs_text_safe_encoding(self, monkeypatch):
+        stdout = _BinaryStdout(isatty=True)
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        result = await self.dda._cli_fetch_message_attachment(
+            "https://example.com/attachments/123", base64=True
+        )
+
+        assert result is None
+        assert stdout.text.getvalue() == "AAH/Cg==\n"
+        assert stdout.buffer.getvalue() == b""
+
+    @pytest.mark.asyncio
+    async def test_base64_and_output_are_mutually_exclusive(self, tmp_path):
+        with pytest.raises(ValueError, match="cannot be used together"):
+            await self.dda._cli_fetch_message_attachment(
+                "https://example.com/attachments/123",
+                output=str(tmp_path / "download.bin"),
+                base64=True,
+            )
+
+        self.dda.fetch_message_attachment.assert_not_awaited()
+        self.dda.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_output_writes_file_and_returns_metadata(self, tmp_path):
+        output = tmp_path / "download.bin"
+
+        result = await self.dda._cli_fetch_message_attachment(
+            "https://example.com/attachments/123", output=str(output)
+        )
+
+        assert output.read_bytes() == b"\x00\x01\xff\n"
+        assert result == {
+            "path": str(output),
+            "content_type": "application/octet-stream",
+            "size": 4,
+        }
+
+    @pytest.mark.asyncio
+    async def test_existing_output_requires_force(self, tmp_path):
+        output = tmp_path / "download.bin"
+        output.write_bytes(b"existing")
+
+        with pytest.raises(FileExistsError, match="--force"):
+            await self.dda._cli_fetch_message_attachment(
+                "https://example.com/attachments/123", output=str(output)
+            )
+
+        assert output.read_bytes() == b"existing"
+        self.dda.fetch_message_attachment.assert_not_awaited()
+        self.dda.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_force_overwrites_existing_output(self, tmp_path):
+        output = tmp_path / "download.bin"
+        output.write_bytes(b"existing")
+
+        await self.dda._cli_fetch_message_attachment(
+            "https://example.com/attachments/123",
+            output=str(output),
+            force=True,
+        )
+
+        assert output.read_bytes() == b"\x00\x01\xff\n"
 
 
 # ── MockDeviceAgentInterface ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- expose `fetch_message_attachment` as a URL-only CLI command while preserving the typed Python API
- support exact file output, safe overwrite handling, ASCII stdout, raw binary pipes/redirection, and explicit Base64 output
- send CLI command errors to stderr so redirected attachment data is not corrupted
- bump the package patch version from `1.9.2` to `1.9.3`

## Root cause

The reflected CLI attempted to construct an `Attachment` model from one positional string even though that model requires four fields. Even if parsing succeeded, the generic result path could not safely emit or save the returned binary file.

## User impact

Users can now download an attachment using only its URL:

```bash
pydoover device_agent fetch_message_attachment URL --output attachment.bin
pydoover device_agent fetch_message_attachment URL > attachment.bin
pydoover device_agent fetch_message_attachment URL --base64
```

ASCII content is printed as text. Binary content streams unchanged when stdout is redirected, while interactive binary output is refused with guidance.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 420 passed, 21 skipped
- `uv build` — built `pydoover-1.9.3` wheel and source distribution
- branch is based directly on current `upstream/main` with no merge conflicts