### PR TITLE
Bump version to 1.9.4

### DIFF
--- a/pydoover/__init__.py
+++ b/pydoover/__init__.py
@@ -1,4 +1,4 @@
 __title__ = "pydoover"
-__version__ = "1.9.3"
+__version__ = "1.9.4"
 
 from . import *  # noqa: F403


### PR DESCRIPTION
## Summary

Bump the package version from `1.9.3` to `1.9.4` so the merged attachment CLI changes can be released under an unused patch version.

## Scope

This PR changes only `pydoover/__init__.py`, the package's single version source.

## Validation

- imported `pydoover.__version__` and confirmed `1.9.4`
- `ruff check pydoover/__init__.py`
- `ruff format --check pydoover/__init__.py`
- `pytest -q` — 421 passed, 21 skipped
- `uv build` — built `pydoover-1.9.4` wheel and source distribution
- branch is based directly on current `upstream/main` with no merge conflicts