### PR TITLE
Add application visibility configuration

### DIFF
--- a/pydoover/config/__init__.py
+++ b/pydoover/config/__init__.py
@@ -1163,7 +1163,7 @@ class ApplicationInterpreterVisible(Boolean):
             description=description,
             default=default,
             name="interpreter_visible",
-            hidden=True,
+            advanced=True,
             **kwargs,
         )
 
@@ -1182,7 +1182,7 @@ class ApplicationCockpitVisible(Boolean):
             description=description,
             default=default,
             name="cockpit_visible",
-            hidden=True,
+            advanced=True,
             **kwargs,
         )
 

--- a/pydoover/config/__init__.py
+++ b/pydoover/config/__init__.py
@@ -1149,6 +1149,44 @@ class ApplicationDefaultOpen(Boolean):
         )
 
 
+class ApplicationInterpreterVisible(Boolean):
+    def __init__(
+        self,
+        display_name: str = "Interpreter Visible",
+        *,
+        description: str = "Whether the application is visible in the interpreter.",
+        default: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            display_name,
+            description=description,
+            default=default,
+            name="interpreter_visible",
+            hidden=True,
+            **kwargs,
+        )
+
+
+class ApplicationCockpitVisible(Boolean):
+    def __init__(
+        self,
+        display_name: str = "Cockpit Visible",
+        *,
+        description: str = "Whether the application's custom widgets are visible in a Cockpit tab.",
+        default: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            display_name,
+            description=description,
+            default=default,
+            name="cockpit_visible",
+            hidden=True,
+            **kwargs,
+        )
+
+
 class TagRef(Object):
     """Represents a reference to a tag exposed by another application (or, in
     future, another agent).

--- a/pydoover/config/__init__.py
+++ b/pydoover/config/__init__.py
@@ -1149,20 +1149,20 @@ class ApplicationDefaultOpen(Boolean):
         )
 
 
-class ApplicationInterpreterVisible(Boolean):
+class ApplicationInterpreterHidden(Boolean):
     def __init__(
         self,
-        display_name: str = "Interpreter Visible",
+        display_name: str = "Interpreter Hidden",
         *,
-        description: str = "Whether the application is visible in the interpreter.",
-        default: bool = True,
+        description: str = "Whether the application is hidden in the interpreter.",
+        default: bool = False,
         **kwargs,
     ):
         super().__init__(
             display_name,
             description=description,
             default=default,
-            name="interpreter_visible",
+            name="interpreter_hidden",
             advanced=True,
             **kwargs,
         )

--- a/pydoover/ui/declarative.py
+++ b/pydoover/ui/declarative.py
@@ -118,7 +118,8 @@ class UI:
     def __init_subclass__(
         cls,
         display_name: str = "$config.app().APP_DISPLAY_NAME",
-        hidden: bool | str = "$config.app().hidden:boolean:false",
+        hidden: bool | str | None = None,
+        interpreter_visible: bool | None = None,
         position: int | str = "$config.app().dv_app_position:number:100",
         default_open: bool
         | str = "$config.app().dv_app_default_open:boolean",  # default to None
@@ -143,6 +144,15 @@ class UI:
             setattr(cls, attr_name, declaration)
 
         cls.__ui_declarations__ = declarations
+
+        if hidden is not None and interpreter_visible is not None:
+            raise ValueError(
+                "Set either `hidden` or `interpreter_visible` on a UI, not both."
+            )
+        if interpreter_visible is not None:
+            hidden = not interpreter_visible
+        elif hidden is None:
+            hidden = "$config.app().hidden:boolean:false"
 
         if isinstance(hidden, str):
             if not hidden.startswith("$"):

--- a/pydoover/ui/declarative.py
+++ b/pydoover/ui/declarative.py
@@ -150,6 +150,8 @@ class UI:
                 "Set either `hidden` or `interpreter_visible` on a UI, not both."
             )
         if interpreter_visible is not None:
+            if not isinstance(interpreter_visible, bool):
+                raise TypeError("`interpreter_visible` must be a boolean.")
             hidden = not interpreter_visible
         elif hidden is None:
             hidden = "$config.app().hidden:boolean:false"

--- a/pydoover/ui/declarative.py
+++ b/pydoover/ui/declarative.py
@@ -118,8 +118,7 @@ class UI:
     def __init_subclass__(
         cls,
         display_name: str = "$config.app().APP_DISPLAY_NAME",
-        hidden: bool | str | None = None,
-        interpreter_visible: bool | None = None,
+        hidden: bool | str = "$config.app().interpreter_hidden",
         position: int | str = "$config.app().dv_app_position:number:100",
         default_open: bool
         | str = "$config.app().dv_app_default_open:boolean",  # default to None
@@ -144,17 +143,6 @@ class UI:
             setattr(cls, attr_name, declaration)
 
         cls.__ui_declarations__ = declarations
-
-        if hidden is not None and interpreter_visible is not None:
-            raise ValueError(
-                "Set either `hidden` or `interpreter_visible` on a UI, not both."
-            )
-        if interpreter_visible is not None:
-            if not isinstance(interpreter_visible, bool):
-                raise TypeError("`interpreter_visible` must be a boolean.")
-            hidden = not interpreter_visible
-        elif hidden is None:
-            hidden = "$config.app().hidden:boolean:false"
 
         if isinstance(hidden, str):
             if not hidden.startswith("$"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,43 @@ SAMPLE_CONFIG_A = {
 }
 
 
+class ApplicationVisibilityConfig(config.Schema):
+    interpreter_visible = config.ApplicationInterpreterVisible()
+    cockpit_visible = config.ApplicationCockpitVisible()
+
+
+class TestApplicationVisibilityConfig:
+    def test_visibility_elements_have_expected_schema_defaults(self):
+        schema = ApplicationVisibilityConfig.to_schema()
+
+        interpreter = schema["properties"]["interpreter_visible"]
+        cockpit = schema["properties"]["cockpit_visible"]
+
+        assert interpreter["type"] == ["boolean", "null"]
+        assert interpreter["default"] is True
+        assert interpreter["x-hidden"] is True
+        assert cockpit["type"] == ["boolean", "null"]
+        assert cockpit["default"] is False
+        assert cockpit["x-hidden"] is True
+        assert schema["required"] == []
+
+    def test_visibility_elements_load_defaults_when_omitted(self):
+        schema = ApplicationVisibilityConfig()
+        schema._inject_deployment_config({})
+
+        assert schema.interpreter_visible.value is True
+        assert schema.cockpit_visible.value is False
+
+    def test_visibility_elements_accept_explicit_overrides(self):
+        schema = ApplicationVisibilityConfig()
+        schema._inject_deployment_config(
+            {"interpreter_visible": False, "cockpit_visible": True}
+        )
+
+        assert schema.interpreter_visible.value is False
+        assert schema.cockpit_visible.value is True
+
+
 class TestConfigSchemaA:
     def test_ok_schema(self):
         validate(deepcopy(SAMPLE_CONFIG_A), ConfigSchemaA().to_schema())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ SAMPLE_CONFIG_A = {
 
 
 class ApplicationVisibilityConfig(config.Schema):
-    interpreter_visible = config.ApplicationInterpreterVisible()
+    interpreter_hidden = config.ApplicationInterpreterHidden()
     cockpit_visible = config.ApplicationCockpitVisible()
 
 
@@ -44,11 +44,11 @@ class TestApplicationVisibilityConfig:
     def test_visibility_elements_have_expected_schema_defaults(self):
         schema = ApplicationVisibilityConfig.to_schema()
 
-        interpreter = schema["properties"]["interpreter_visible"]
+        interpreter = schema["properties"]["interpreter_hidden"]
         cockpit = schema["properties"]["cockpit_visible"]
 
         assert interpreter["type"] == ["boolean", "null"]
-        assert interpreter["default"] is True
+        assert interpreter["default"] is False
         assert interpreter["x-hidden"] is False
         assert interpreter["x-advanced"] is True
         assert cockpit["type"] == ["boolean", "null"]
@@ -61,16 +61,16 @@ class TestApplicationVisibilityConfig:
         schema = ApplicationVisibilityConfig()
         schema._inject_deployment_config({})
 
-        assert schema.interpreter_visible.value is True
+        assert schema.interpreter_hidden.value is False
         assert schema.cockpit_visible.value is False
 
     def test_visibility_elements_accept_explicit_overrides(self):
         schema = ApplicationVisibilityConfig()
         schema._inject_deployment_config(
-            {"interpreter_visible": False, "cockpit_visible": True}
+            {"interpreter_hidden": True, "cockpit_visible": True}
         )
 
-        assert schema.interpreter_visible.value is False
+        assert schema.interpreter_hidden.value is True
         assert schema.cockpit_visible.value is True
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,10 +49,12 @@ class TestApplicationVisibilityConfig:
 
         assert interpreter["type"] == ["boolean", "null"]
         assert interpreter["default"] is True
-        assert interpreter["x-hidden"] is True
+        assert interpreter["x-hidden"] is False
+        assert interpreter["x-advanced"] is True
         assert cockpit["type"] == ["boolean", "null"]
         assert cockpit["default"] is False
-        assert cockpit["x-hidden"] is True
+        assert cockpit["x-hidden"] is False
+        assert cockpit["x-advanced"] is True
         assert schema["required"] == []
 
     def test_visibility_elements_load_defaults_when_omitted(self):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -350,6 +350,15 @@ class TestConfigRefResolution:
             class MyUI(ui.UI, hidden=False, interpreter_visible=True):
                 pass
 
+    def test_interpreter_visibility_rejects_config_reference_strings(self):
+        with pytest.raises(TypeError, match="must be a boolean"):
+
+            class MyUI(
+                ui.UI,
+                interpreter_visible="$config.app().interpreter_visible",
+            ):
+                pass
+
 
 class TestApplicationUIResolution:
     def test_async_docker_startup_binds_dynamic_ui_to_runtime_tags(self, monkeypatch):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -330,6 +330,26 @@ class TestConfigRefResolution:
 
         assert MyUI(schema, None, "app_key").to_schema()["position"] == 100
 
+    @pytest.mark.parametrize(
+        ("interpreter_visible", "expected_hidden"),
+        [(True, False), (False, True)],
+    )
+    def test_interpreter_visibility_is_inverted_for_ui_hidden(
+        self, interpreter_visible, expected_hidden
+    ):
+        class MyUI(ui.UI, interpreter_visible=interpreter_visible):
+            pass
+
+        assert MyUI(None, None, "app_key").to_schema()["hidden"] is expected_hidden
+
+    def test_interpreter_visibility_and_hidden_are_mutually_exclusive(self):
+        with pytest.raises(
+            ValueError, match="either `hidden` or `interpreter_visible`"
+        ):
+
+            class MyUI(ui.UI, hidden=False, interpreter_visible=True):
+                pass
+
 
 class TestApplicationUIResolution:
     def test_async_docker_startup_binds_dynamic_ui_to_runtime_tags(self, monkeypatch):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -330,34 +330,38 @@ class TestConfigRefResolution:
 
         assert MyUI(schema, None, "app_key").to_schema()["position"] == 100
 
-    @pytest.mark.parametrize(
-        ("interpreter_visible", "expected_hidden"),
-        [(True, False), (False, True)],
-    )
-    def test_interpreter_visibility_is_inverted_for_ui_hidden(
-        self, interpreter_visible, expected_hidden
-    ):
-        class MyUI(ui.UI, interpreter_visible=interpreter_visible):
+    def test_resolves_interpreter_hidden_from_explicit_deployment_value(self):
+        class S(config.Schema):
+            interpreter_hidden = config.ApplicationInterpreterHidden()
+
+        schema = S()
+        schema._inject_deployment_config({"interpreter_hidden": True})
+
+        class MyUI(ui.UI):
             pass
 
-        assert MyUI(None, None, "app_key").to_schema()["hidden"] is expected_hidden
+        assert MyUI(schema, None, "app_key").to_schema()["hidden"] is True
 
-    def test_interpreter_visibility_and_hidden_are_mutually_exclusive(self):
-        with pytest.raises(
-            ValueError, match="either `hidden` or `interpreter_visible`"
-        ):
+    def test_resolves_interpreter_hidden_from_config_default(self):
+        class S(config.Schema):
+            interpreter_hidden = config.ApplicationInterpreterHidden()
 
-            class MyUI(ui.UI, hidden=False, interpreter_visible=True):
-                pass
+        schema = S()
+        schema._inject_deployment_config({})
 
-    def test_interpreter_visibility_rejects_config_reference_strings(self):
-        with pytest.raises(TypeError, match="must be a boolean"):
+        class MyUI(ui.UI):
+            pass
 
-            class MyUI(
-                ui.UI,
-                interpreter_visible="$config.app().interpreter_visible",
-            ):
-                pass
+        assert MyUI(schema, None, "app_key").to_schema()["hidden"] is False
+
+    def test_exports_interpreter_hidden_config_reference(self):
+        class MyUI(ui.UI):
+            pass
+
+        assert (
+            MyUI(None, None, "app_key").to_schema(resolve_config=False)["hidden"]
+            == "$config.app().interpreter_hidden:boolean:false"
+        )
 
 
 class TestApplicationUIResolution:


### PR DESCRIPTION
## Summary

- add reusable optional `ApplicationInterpreterHidden` and `ApplicationCockpitVisible` configuration elements
- expose both as advanced configuration parameters using the deployment keys `interpreter_hidden` and `cockpit_visible`
- default both settings to `false`
- make the top-level `UI.hidden` field resolve from `$config.app().interpreter_hidden:boolean:false` by default

## Impact

Applications can opt into these common configuration fields without repeating names, metadata, or defaults. The default UI now uses the same negative `interpreter_hidden` semantics as its underlying `hidden` field, so exported schemas retain a normal string config reference without requiring inversion support.

## Validation

- `uv run pytest` — 440 passed, 21 skipped
- `uv run ruff check pydoover/config/__init__.py pydoover/ui/declarative.py tests/test_config.py tests/test_ui.py`
- `uv run ruff format --check pydoover/config/__init__.py pydoover/ui/declarative.py tests/test_config.py tests/test_ui.py`
- `uvx ty check pydoover/config/__init__.py pydoover/ui/declarative.py`